### PR TITLE
add packages typed for EST, PST & UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,20 @@
 [![codecov](https://codecov.io/gh/matthalp/go-meridian/branch/main/graph/badge.svg)](https://codecov.io/gh/matthalp/go-meridian)
 [![Go Report Card](https://goreportcard.com/badge/github.com/matthalp/go-meridian)](https://goreportcard.com/report/github.com/matthalp/go-meridian)
 
-A Go 1.20 package/library with comprehensive CI/CD pipeline.
+**Type-safe timezone handling for Go using generics.**
+
+Meridian solves a fundamental problem: timezone information in `time.Time` is data, not type, and can be lost without the compiler noticing. With Meridian, timezone information is encoded directly into the type system, making wrong timezone handling impossible to compile.
 
 ## Features
 
+- ✅ **Type-safe timezones**: `utc.Time` and `est.Time` are different types
+- ✅ **Compiler-enforced correctness**: Prevents accidental timezone mixing
+- ✅ **Clean, ergonomic API**: `utc.Now()`, `est.Date(...)`, `pst.Time`
+- ✅ **Built-in timezone packages**: UTC, EST, PST included
+- ✅ **Extensible**: Easy to add custom timezone packages
 - ✅ Full GitHub Actions CI/CD pipeline
 - ✅ Automated testing with coverage reports
-- ✅ Code linting with golangci-lint
 - ✅ Race condition detection
-- ✅ Coverage reports uploaded to Codecov
-- ✅ Importable as a Go module
 
 ## Installation
 
@@ -23,27 +27,67 @@ Install the package in your Go project:
 go get github.com/matthalp/go-meridian
 ```
 
-## Usage
+## Quick Start
 
-Import and use the package in your code:
+Import and use timezone-specific packages:
 
 ```go
 package main
 
 import (
     "fmt"
-    "github.com/matthalp/go-meridian"
+    "time"
+    
+    "github.com/matthalp/go-meridian/est"
+    "github.com/matthalp/go-meridian/utc"
 )
 
 func main() {
-    // Use the Greet function
-    greeting := meridian.Greet("World")
-    fmt.Println(greeting) // Output: Hello, World!
+    // Get current time in different timezones
+    now := utc.Now()
+    fmt.Println(now.Format(time.RFC3339))
+    
+    // Create a specific date/time
+    meeting := est.Date(2024, time.December, 25, 10, 30, 0, 0)
+    fmt.Println(meeting.Format(time.Kitchen))
+    
+    // Type-safe function signatures
+    storeInDatabase(utc.Now())  // ✅ Compiles
+    // storeInDatabase(est.Now()) // ❌ Won't compile!
+}
 
-    // Check the version
-    fmt.Printf("Version: %s\n", meridian.Version)
+// Functions can require specific timezones
+func storeInDatabase(t utc.Time) {
+    // Always receives UTC time, guaranteed by the compiler
 }
 ```
+
+## Why Meridian?
+
+**Problem**: Standard Go `time.Time` loses timezone information easily:
+```go
+t := time.Now().UTC()
+// Later in code...
+formatted := t.Format(time.Kitchen) // What timezone is this? 🤷
+```
+
+**Solution**: Meridian encodes timezone in the type:
+```go
+t := utc.Now()
+// Later in code...
+formatted := t.Format(time.Kitchen) // Definitely UTC! ✅
+```
+
+## Available Timezone Packages
+
+- `github.com/matthalp/go-meridian/utc` - Coordinated Universal Time
+- `github.com/matthalp/go-meridian/est` - Eastern Standard Time (America/New_York)
+- `github.com/matthalp/go-meridian/pst` - Pacific Standard Time (America/Los_Angeles)
+
+Each package provides:
+- `Now()` - Get current time in that timezone
+- `Date()` - Create a specific date/time
+- `Time` - Type alias for clean function signatures
 
 ### Running the Example
 
@@ -98,12 +142,21 @@ Coverage reports are automatically uploaded to Codecov for tracking test coverag
 ├── cmd/
 │   └── example/
 │       └── main.go         # Example usage program
+├── est/                    # Eastern Time timezone package
+│   ├── est.go
+│   └── est_test.go
+├── pst/                    # Pacific Time timezone package
+│   ├── pst.go
+│   └── pst_test.go
+├── utc/                    # UTC timezone package
+│   ├── utc.go
+│   └── utc_test.go
 ├── .golangci.yml           # Linter configuration
 ├── doc.go                  # Package documentation
 ├── example_test.go         # Testable examples
 ├── go.mod                  # Go module file
-├── meridian.go             # Main package code
-├── meridian_test.go        # Package tests
+├── meridian.go             # Core generic types and functions
+├── meridian_test.go        # Core package tests
 ├── Makefile                # Development tasks
 └── README.md               # This file
 ```

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -6,24 +6,10 @@ import (
 	"time"
 
 	"github.com/matthalp/go-meridian"
+	"github.com/matthalp/go-meridian/est"
+	"github.com/matthalp/go-meridian/pst"
+	"github.com/matthalp/go-meridian/utc"
 )
-
-// UTC represents the Coordinated Universal Time timezone.
-type UTC struct{}
-
-// Location returns the UTC time.Location.
-func (UTC) Location() *time.Location {
-	return time.UTC
-}
-
-// EST represents the Eastern Standard Time timezone.
-type EST struct{}
-
-// Location returns the EST time.Location.
-func (EST) Location() *time.Location {
-	loc, _ := time.LoadLocation("America/New_York")
-	return loc
-}
 
 func main() {
 	fmt.Println("Meridian Package Example")
@@ -32,22 +18,41 @@ func main() {
 
 	// Example 1: Get current time in different timezones
 	fmt.Println("1. Current Time:")
-	utcNow := meridian.Now[UTC]()
-	estNow := meridian.Now[EST]()
+	utcNow := utc.Now()
+	estNow := est.Now()
+	pstNow := pst.Now()
 	fmt.Printf("   UTC: %s\n", utcNow.Format(time.RFC3339))
 	fmt.Printf("   EST: %s\n", estNow.Format(time.RFC3339))
+	fmt.Printf("   PST: %s\n", pstNow.Format(time.RFC3339))
 	fmt.Println()
 
 	// Example 2: Create a specific date
 	fmt.Println("2. Specific Date:")
-	meeting := meridian.Date[EST](2024, time.December, 25, 10, 30, 0, 0)
+	meeting := est.Date(2024, time.December, 25, 10, 30, 0, 0)
 	fmt.Printf("   Meeting time (EST): %s\n", meeting.Format("Monday, January 2, 2006 at 3:04 PM MST"))
 	fmt.Println()
 
 	// Example 3: Different time formats
 	fmt.Println("3. Different Formats:")
-	t := meridian.Date[UTC](2024, time.June, 15, 14, 30, 45, 0)
+	t := utc.Date(2024, time.June, 15, 14, 30, 45, 0)
 	fmt.Printf("   RFC3339: %s\n", t.Format(time.RFC3339))
 	fmt.Printf("   Kitchen: %s\n", t.Format(time.Kitchen))
 	fmt.Printf("   Custom:  %s\n", t.Format("2006-01-02 15:04:05"))
+	fmt.Println()
+
+	// Example 4: Type-safe function signatures using timezone-specific types
+	fmt.Println("4. Type-Safe Function Signatures:")
+	printUTCTime(utc.Now())
+	printESTTime(est.Now())
+	// Note: printUTCTime(est.Now()) would not compile due to type safety
+}
+
+// printUTCTime accepts only UTC times.
+func printUTCTime(t utc.Time) {
+	fmt.Printf("   UTC Time: %s\n", t.Format(time.RFC3339))
+}
+
+// printESTTime accepts only EST times.
+func printESTTime(t est.Time) {
+	fmt.Printf("   EST Time: %s\n", t.Format(time.RFC3339))
 }

--- a/est/est.go
+++ b/est/est.go
@@ -1,0 +1,43 @@
+// Package est provides Eastern Standard Time timezone support for meridian.
+package est
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/matthalp/go-meridian"
+)
+
+// location is the IANA timezone location, loaded once at package initialization.
+var location = mustLoadLocation("America/New_York")
+
+// mustLoadLocation loads a timezone location or panics if it fails.
+// This should only fail if the system's timezone database is corrupted or missing.
+func mustLoadLocation(name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		panic(fmt.Sprintf("failed to load timezone %s: %v", name, err))
+	}
+	return loc
+}
+
+// Timezone represents the Eastern Standard Time timezone.
+type Timezone struct{}
+
+// Location returns the IANA timezone location.
+func (Timezone) Location() *time.Location {
+	return location
+}
+
+// Time is a convenience alias for meridian.Time[Timezone].
+type Time = meridian.Time[Timezone]
+
+// Now returns the current time in this timezone.
+func Now() Time {
+	return meridian.Now[Timezone]()
+}
+
+// Date creates a new time in this timezone with the specified date and time components.
+func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
+	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
+}

--- a/est/est_test.go
+++ b/est/est_test.go
@@ -1,0 +1,63 @@
+package est
+
+import (
+	"testing"
+	"time"
+)
+
+func TestESTLocation(t *testing.T) {
+	var tz Timezone
+	loc := tz.Location()
+	if loc.String() != "America/New_York" {
+		t.Errorf("Timezone.Location() = %v, want America/New_York", loc.String())
+	}
+}
+
+func TestNow(t *testing.T) {
+	before := time.Now().UTC()
+	tzTime := Now()
+	after := time.Now().UTC()
+
+	// Parse back to verify it's within range
+	parsed, err := time.Parse(time.RFC3339, tzTime.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+
+	if parsed.Before(before.Add(-time.Second)) || parsed.After(after.Add(time.Second)) {
+		t.Errorf("Now() returned time outside expected range: got %v, expected between %v and %v", parsed, before, after)
+	}
+}
+
+func TestDate(t *testing.T) {
+	// Create a time: Jan 15, 2024 at noon EST
+	tzTime := Date(2024, time.January, 15, 12, 0, 0, 0)
+
+	// Format should show the time in EST
+	result := tzTime.Format("15:04 MST")
+
+	// Should show noon in EST
+	if result != "12:00 EST" {
+		t.Errorf("Format() = %q, want %q", result, "12:00 EST")
+	}
+}
+
+func TestDateWithOffset(t *testing.T) {
+	// Create a time in EST (UTC-5 in winter)
+	// Noon EST should be 5 PM UTC
+	tzTime := Date(2024, time.January, 1, 12, 0, 0, 0)
+
+	// Parse the formatted time and convert to UTC to verify
+	parsed, err := time.Parse(time.RFC3339, tzTime.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+	utcTime := parsed.UTC()
+
+	// 12:00 EST + 5 hours = 17:00 UTC
+	expected := time.Date(2024, time.January, 1, 17, 0, 0, 0, time.UTC)
+
+	if !utcTime.Equal(expected) {
+		t.Errorf("Date() in UTC = %v, want %v", utcTime, expected)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -4,19 +4,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian"
+	"github.com/matthalp/go-meridian/utc"
 )
-
-// UTC timezone for examples.
-type UTC struct{}
-
-func (UTC) Location() *time.Location {
-	return time.UTC
-}
 
 func ExampleNow() {
 	// Get the current time in UTC
-	now := meridian.Now[UTC]()
+	now := utc.Now()
 
 	// Format it
 	fmt.Println("Current time format:", now.Format("2006-01-02"))
@@ -25,7 +18,7 @@ func ExampleNow() {
 
 func ExampleDate() {
 	// Create a specific time in UTC
-	t := meridian.Date[UTC](2024, time.January, 15, 14, 30, 0, 0)
+	t := utc.Date(2024, time.January, 15, 14, 30, 0, 0)
 
 	// Format the time
 	fmt.Println(t.Format("2006-01-02 15:04:05"))
@@ -34,7 +27,7 @@ func ExampleDate() {
 
 func ExampleTime_Format() {
 	// Create a specific time in UTC
-	t := meridian.Date[UTC](2024, time.June, 15, 9, 30, 0, 0)
+	t := utc.Date(2024, time.June, 15, 9, 30, 0, 0)
 
 	// Format the time in different layouts
 	fmt.Println(t.Format(time.RFC3339))

--- a/pst/pst.go
+++ b/pst/pst.go
@@ -1,0 +1,43 @@
+// Package pst provides Pacific Standard Time timezone support for meridian.
+package pst
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/matthalp/go-meridian"
+)
+
+// location is the IANA timezone location, loaded once at package initialization.
+var location = mustLoadLocation("America/Los_Angeles")
+
+// mustLoadLocation loads a timezone location or panics if it fails.
+// This should only fail if the system's timezone database is corrupted or missing.
+func mustLoadLocation(name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		panic(fmt.Sprintf("failed to load timezone %s: %v", name, err))
+	}
+	return loc
+}
+
+// Timezone represents the Pacific Standard Time timezone.
+type Timezone struct{}
+
+// Location returns the IANA timezone location.
+func (Timezone) Location() *time.Location {
+	return location
+}
+
+// Time is a convenience alias for meridian.Time[Timezone].
+type Time = meridian.Time[Timezone]
+
+// Now returns the current time in this timezone.
+func Now() Time {
+	return meridian.Now[Timezone]()
+}
+
+// Date creates a new time in this timezone with the specified date and time components.
+func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
+	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
+}

--- a/pst/pst_test.go
+++ b/pst/pst_test.go
@@ -1,0 +1,63 @@
+package pst
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPSTLocation(t *testing.T) {
+	var tz Timezone
+	loc := tz.Location()
+	if loc.String() != "America/Los_Angeles" {
+		t.Errorf("Timezone.Location() = %v, want America/Los_Angeles", loc.String())
+	}
+}
+
+func TestNow(t *testing.T) {
+	before := time.Now().UTC()
+	tzTime := Now()
+	after := time.Now().UTC()
+
+	// Parse back to verify it's within range
+	parsed, err := time.Parse(time.RFC3339, tzTime.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+
+	if parsed.Before(before.Add(-time.Second)) || parsed.After(after.Add(time.Second)) {
+		t.Errorf("Now() returned time outside expected range: got %v, expected between %v and %v", parsed, before, after)
+	}
+}
+
+func TestDate(t *testing.T) {
+	// Create a time: Jan 15, 2024 at noon PST
+	tzTime := Date(2024, time.January, 15, 12, 0, 0, 0)
+
+	// Format should show the time in PST
+	result := tzTime.Format("15:04 MST")
+
+	// Should show noon in PST
+	if result != "12:00 PST" {
+		t.Errorf("Format() = %q, want %q", result, "12:00 PST")
+	}
+}
+
+func TestDateWithOffset(t *testing.T) {
+	// Create a time in PST (UTC-8 in winter)
+	// Noon PST should be 8 PM UTC
+	tzTime := Date(2024, time.January, 1, 12, 0, 0, 0)
+
+	// Parse the formatted time and convert to UTC to verify
+	parsed, err := time.Parse(time.RFC3339, tzTime.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+	utcTime := parsed.UTC()
+
+	// 12:00 PST + 8 hours = 20:00 UTC
+	expected := time.Date(2024, time.January, 1, 20, 0, 0, 0, time.UTC)
+
+	if !utcTime.Equal(expected) {
+		t.Errorf("Date() in UTC = %v, want %v", utcTime, expected)
+	}
+}

--- a/utc/utc.go
+++ b/utc/utc.go
@@ -1,0 +1,32 @@
+// Package utc provides Coordinated Universal Time timezone support for meridian.
+package utc
+
+import (
+	"time"
+
+	"github.com/matthalp/go-meridian"
+)
+
+// location is the IANA timezone location, loaded once at package initialization.
+var location = time.UTC
+
+// Timezone represents the Coordinated Universal Time timezone.
+type Timezone struct{}
+
+// Location returns the IANA timezone location.
+func (Timezone) Location() *time.Location {
+	return location
+}
+
+// Time is a convenience alias for meridian.Time[Timezone].
+type Time = meridian.Time[Timezone]
+
+// Now returns the current time in this timezone.
+func Now() Time {
+	return meridian.Now[Timezone]()
+}
+
+// Date creates a new time in this timezone with the specified date and time components.
+func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
+	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
+}

--- a/utc/utc_test.go
+++ b/utc/utc_test.go
@@ -1,0 +1,78 @@
+package utc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUTCLocation(t *testing.T) {
+	var tz Timezone
+	loc := tz.Location()
+	if loc != time.UTC {
+		t.Errorf("Timezone.Location() = %v, want %v", loc, time.UTC)
+	}
+}
+
+func TestNow(t *testing.T) {
+	before := time.Now().UTC()
+	tzTime := Now()
+	after := time.Now().UTC()
+
+	// Format to get the underlying time for comparison
+	// Parse back to verify it's within range
+	parsed, err := time.Parse(time.RFC3339, tzTime.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+
+	if parsed.Before(before.Add(-time.Second)) || parsed.After(after.Add(time.Second)) {
+		t.Errorf("Now() returned time outside expected range: got %v, expected between %v and %v", parsed, before, after)
+	}
+}
+
+func TestDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		year     int
+		month    time.Month
+		day      int
+		hour     int
+		min      int
+		sec      int
+		nsec     int
+		expected string
+	}{
+		{
+			name:     "midnight on New Year 2024",
+			year:     2024,
+			month:    time.January,
+			day:      1,
+			hour:     0,
+			min:      0,
+			sec:      0,
+			nsec:     0,
+			expected: "2024-01-01T00:00:00Z",
+		},
+		{
+			name:     "noon",
+			year:     2024,
+			month:    time.June,
+			day:      15,
+			hour:     12,
+			min:      30,
+			sec:      45,
+			nsec:     0,
+			expected: "2024-06-15T12:30:45Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tzTime := Date(tt.year, tt.month, tt.day, tt.hour, tt.min, tt.sec, tt.nsec)
+			result := tzTime.Format(time.RFC3339)
+			if result != tt.expected {
+				t.Errorf("Date() formatted as %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Creates timezone-specific subpackages that provide a clean, ergonomic API
for type-safe timezone handling. Each package (utc, est, pst) provides:

- Timezone type implementing meridian.Timezone interface
- Time type alias (e.g., utc.Time, est.Time) for clean function signatures
- Now() and Date() helper functions
- Cached location loading for performance

This enables compiler-enforced timezone correctness:
- utc.Time and est.Time are different types
- Functions can require specific timezones (e.g., func store(t utc.Time))
- Prevents accidental timezone mixing at compile time

Also updates all documentation (README, USAGE, AGENTS) with examples
and guidance for using the new timezone packages.