### PR TITLE
add Moment interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,28 @@ formatted := t.Format(time.Kitchen) // Definitely UTC! ✅
 Each package provides:
 - `Now()` - Get current time in that timezone
 - `Date()` - Create a specific date/time
+- `Convert()` - Convert any time to that timezone
 - `Time` - Type alias for clean function signatures
+
+## Converting Between Timezones
+
+Meridian provides seamless timezone conversion while preserving type safety:
+
+```go
+// Convert between timezone types
+estTime := est.Date(2024, time.December, 25, 10, 30, 0, 0)
+utcTime := utc.Convert(estTime)  // Same moment, displayed as UTC
+pstTime := pst.Convert(estTime)  // Same moment, displayed as PST
+
+// Convert from standard time.Time
+stdTime := time.Now()
+typedTime := utc.Convert(stdTime)  // Now type-safe!
+
+// All conversions preserve the moment in time
+fmt.Println(estTime.UTC().Equal(utcTime.UTC()))  // true
+```
+
+The `Moment` interface allows both `time.Time` and `meridian.Time[TZ]` to be used interchangeably for conversions, providing flexibility while maintaining type safety where it matters.
 
 ### Running the Example
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -82,6 +82,92 @@ func main() {
 }
 ```
 
+### Converting Between Timezones
+
+Meridian provides `Convert()` functions in each timezone package to convert between timezones:
+
+```go
+package main
+
+import (
+    "fmt"
+    "time"
+    
+    "github.com/matthalp/go-meridian/est"
+    "github.com/matthalp/go-meridian/pst"
+    "github.com/matthalp/go-meridian/utc"
+)
+
+func main() {
+    // Create a time in EST
+    meeting := est.Date(2024, time.December, 25, 10, 30, 0, 0)
+    
+    // Convert to other timezones
+    utcMeeting := utc.Convert(meeting)
+    pstMeeting := pst.Convert(meeting)
+    
+    fmt.Printf("EST: %s\n", meeting.Format(time.Kitchen))    // 10:30AM
+    fmt.Printf("UTC: %s\n", utcMeeting.Format(time.Kitchen)) // 3:30PM
+    fmt.Printf("PST: %s\n", pstMeeting.Format(time.Kitchen)) // 7:30AM
+    
+    // All represent the same moment in time
+    fmt.Println(meeting.UTC().Equal(utcMeeting.UTC()))  // true
+    fmt.Println(meeting.UTC().Equal(pstMeeting.UTC()))  // true
+}
+```
+
+### Converting from time.Time
+
+The `Moment` interface allows seamless conversion from standard `time.Time`:
+
+```go
+package main
+
+import (
+    "time"
+    "github.com/matthalp/go-meridian/utc"
+    "github.com/matthalp/go-meridian/est"
+)
+
+func processStandardTime(stdTime time.Time) {
+    // Convert to type-safe timezone types
+    utcTime := utc.Convert(stdTime)
+    estTime := est.Convert(stdTime)
+    
+    // Now you have type-safe times for your functions
+    storeInDatabase(utcTime)     // Function requires utc.Time
+    displayToUser(estTime)       // Function requires est.Time
+}
+
+func storeInDatabase(t utc.Time) { /* ... */ }
+func displayToUser(t est.Time) { /* ... */ }
+```
+
+### The Moment Interface
+
+Both `time.Time` and `meridian.Time[TZ]` implement the `Moment` interface:
+
+```go
+type Moment interface {
+    UTC() time.Time
+}
+```
+
+This allows functions to accept times from any source:
+
+```go
+func logEvent(m meridian.Moment, event string) {
+    // Works with time.Time or any meridian.Time[TZ]
+    utcTime := m.UTC()
+    fmt.Printf("[%s] %s\n", utcTime.Format(time.RFC3339), event)
+}
+
+// Can be called with either
+logEvent(time.Now(), "started")
+logEvent(utc.Now(), "processing")
+logEvent(est.Now(), "completed")
+```
+
 ### Advanced Usage - Generic API
 
 For custom timezones or advanced usage, use the generic API:

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -45,6 +45,32 @@ func main() {
 	printUTCTime(utc.Now())
 	printESTTime(est.Now())
 	// Note: printUTCTime(est.Now()) would not compile due to type safety
+	fmt.Println()
+
+	// Example 5: Converting between timezones
+	fmt.Println("5. Timezone Conversion:")
+	estMeeting := est.Date(2024, time.December, 25, 10, 30, 0, 0)
+	utcMeeting := utc.Convert(estMeeting)
+	pstMeeting := pst.Convert(estMeeting)
+
+	fmt.Printf("   Meeting EST: %s\n", estMeeting.Format(time.Kitchen))
+	fmt.Printf("   Meeting UTC: %s\n", utcMeeting.Format(time.Kitchen))
+	fmt.Printf("   Meeting PST: %s\n", pstMeeting.Format(time.Kitchen))
+	fmt.Println()
+
+	// Example 6: Converting from standard time.Time
+	fmt.Println("6. Converting from time.Time:")
+	stdTime := time.Date(2024, time.June, 15, 18, 0, 0, 0, time.UTC)
+	fmt.Printf("   Standard time.Time: %s\n", stdTime.Format(time.RFC3339))
+
+	// Convert to timezone-specific types
+	utcFromStd := utc.Convert(stdTime)
+	estFromStd := est.Convert(stdTime)
+	pstFromStd := pst.Convert(stdTime)
+
+	fmt.Printf("   As UTC: %s\n", utcFromStd.Format("3:04 PM MST"))
+	fmt.Printf("   As EST: %s\n", estFromStd.Format("3:04 PM MST"))
+	fmt.Printf("   As PST: %s\n", pstFromStd.Format("3:04 PM MST"))
 }
 
 // printUTCTime accepts only UTC times.

--- a/est/est.go
+++ b/est/est.go
@@ -41,3 +41,8 @@ func Now() Time {
 func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
 	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
 }
+
+// Convert converts any Moment to EST time.
+func Convert(m meridian.Moment) Time {
+	return meridian.FromMoment[Timezone](m)
+}

--- a/est/est_test.go
+++ b/est/est_test.go
@@ -3,6 +3,9 @@ package est
 import (
 	"testing"
 	"time"
+
+	"github.com/matthalp/go-meridian/pst"
+	"github.com/matthalp/go-meridian/utc"
 )
 
 func TestESTLocation(t *testing.T) {
@@ -60,4 +63,80 @@ func TestDateWithOffset(t *testing.T) {
 	if !utcTime.Equal(expected) {
 		t.Errorf("Date() in UTC = %v, want %v", utcTime, expected)
 	}
+}
+
+func TestConvert(t *testing.T) {
+	t.Run("from time.Time", func(t *testing.T) {
+		// Test converting from standard time.Time in UTC
+		stdTime := time.Date(2024, time.January, 15, 17, 0, 0, 0, time.UTC)
+		estTime := Convert(stdTime)
+
+		// Verify the conversion - should represent same moment
+		if !estTime.UTC().Equal(stdTime) {
+			t.Errorf("Convert(time.Time) UTC = %v, want %v", estTime.UTC(), stdTime)
+		}
+
+		// Verify formatting shows EST (17:00 UTC = 12:00 EST)
+		result := estTime.Format("15:04 MST")
+		if result != "12:00 EST" {
+			t.Errorf("Formatted time = %q, want %q", result, "12:00 EST")
+		}
+	})
+
+	t.Run("from UTC", func(t *testing.T) {
+		// Create 17:00 UTC
+		utcTime := utc.Date(2024, time.January, 15, 17, 0, 0, 0)
+
+		// Convert to EST
+		estTime := Convert(utcTime)
+
+		// 17:00 UTC = 12:00 EST in winter
+		result := estTime.Format("15:04 MST")
+		if result != "12:00 EST" {
+			t.Errorf("Formatted EST time = %q, want %q", result, "12:00 EST")
+		}
+
+		// Verify same moment in time
+		if !estTime.UTC().Equal(utcTime.UTC()) {
+			t.Error("Converted time doesn't represent same moment")
+		}
+	})
+
+	t.Run("from PST", func(t *testing.T) {
+		// Create 9:00 PST
+		pstTime := pst.Date(2024, time.January, 15, 9, 0, 0, 0)
+
+		// Convert to EST
+		estTime := Convert(pstTime)
+
+		// 9:00 PST = 12:00 EST (3 hour difference)
+		result := estTime.Format("15:04 MST")
+		if result != "12:00 EST" {
+			t.Errorf("Formatted EST time = %q, want %q", result, "12:00 EST")
+		}
+
+		// Verify same moment in time
+		if !estTime.UTC().Equal(pstTime.UTC()) {
+			t.Error("Converted time doesn't represent same moment")
+		}
+	})
+
+	t.Run("round trip conversion", func(t *testing.T) {
+		// Create time in EST
+		original := Date(2024, time.January, 15, 14, 30, 0, 0)
+
+		// Convert to UTC and back
+		viaUTC := Convert(utc.Convert(original))
+
+		// Should represent the same moment
+		if !viaUTC.UTC().Equal(original.UTC()) {
+			t.Error("Round trip conversion changed the moment in time")
+		}
+
+		// Should format the same
+		if viaUTC.Format(time.RFC3339) != original.Format(time.RFC3339) {
+			t.Errorf("Round trip format = %q, want %q",
+				viaUTC.Format(time.RFC3339), original.Format(time.RFC3339))
+		}
+	})
 }

--- a/meridian.go
+++ b/meridian.go
@@ -12,6 +12,11 @@ type Timezone interface {
 	Location() *time.Location
 }
 
+// Moment represents a moment in time that can be converted to UTC.
+type Moment interface {
+	UTC() time.Time
+}
+
 // Now returns the current time in the specified timezone.
 func Now[TZ Timezone]() Time[TZ] {
 	return Time[TZ]{utcTime: time.Now().UTC()}
@@ -23,6 +28,12 @@ func Date[TZ Timezone](year int, month time.Month, day, hour, minute, sec, nsec 
 	loc := getLocation[TZ]()
 	t := time.Date(year, month, day, hour, minute, sec, nsec, loc)
 	return Time[TZ]{utcTime: t.UTC()}
+}
+
+// FromMoment creates a Time[TZ] from any Moment (e.g., time.Time or another Time[TZ]).
+// The Moment is converted to UTC and wrapped in the specified timezone type.
+func FromMoment[TZ Timezone](m Moment) Time[TZ] {
+	return Time[TZ]{utcTime: m.UTC()}
 }
 
 // getLocation extracts the *time.Location from a timezone type.
@@ -42,6 +53,11 @@ type Time[TZ Timezone] struct {
 // Format is a wrapper around time.Time.Format that returns the time in the timezone's location.
 func (t Time[TZ]) Format(layout string) string {
 	return t.nativeTimeInLocation().Format(layout)
+}
+
+// UTC returns the time as a standard time.Time in UTC.
+func (t Time[TZ]) UTC() time.Time {
+	return t.utcTime
 }
 
 // nativeTimeInLocation returns the native time in the location of the timezone.

--- a/pst/pst.go
+++ b/pst/pst.go
@@ -41,3 +41,8 @@ func Now() Time {
 func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
 	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
 }
+
+// Convert converts any Moment to PST time.
+func Convert(m meridian.Moment) Time {
+	return meridian.FromMoment[Timezone](m)
+}

--- a/pst/pst_test.go
+++ b/pst/pst_test.go
@@ -3,6 +3,9 @@ package pst
 import (
 	"testing"
 	"time"
+
+	"github.com/matthalp/go-meridian/est"
+	"github.com/matthalp/go-meridian/utc"
 )
 
 func TestPSTLocation(t *testing.T) {
@@ -60,4 +63,80 @@ func TestDateWithOffset(t *testing.T) {
 	if !utcTime.Equal(expected) {
 		t.Errorf("Date() in UTC = %v, want %v", utcTime, expected)
 	}
+}
+
+func TestConvert(t *testing.T) {
+	t.Run("from time.Time", func(t *testing.T) {
+		// Test converting from standard time.Time in UTC
+		stdTime := time.Date(2024, time.January, 15, 20, 0, 0, 0, time.UTC)
+		pstTime := Convert(stdTime)
+
+		// Verify the conversion - should represent same moment
+		if !pstTime.UTC().Equal(stdTime) {
+			t.Errorf("Convert(time.Time) UTC = %v, want %v", pstTime.UTC(), stdTime)
+		}
+
+		// Verify formatting shows PST (20:00 UTC = 12:00 PST)
+		result := pstTime.Format("15:04 MST")
+		if result != "12:00 PST" {
+			t.Errorf("Formatted time = %q, want %q", result, "12:00 PST")
+		}
+	})
+
+	t.Run("from UTC", func(t *testing.T) {
+		// Create 20:00 UTC
+		utcTime := utc.Date(2024, time.January, 15, 20, 0, 0, 0)
+
+		// Convert to PST
+		pstTime := Convert(utcTime)
+
+		// 20:00 UTC = 12:00 PST in winter
+		result := pstTime.Format("15:04 MST")
+		if result != "12:00 PST" {
+			t.Errorf("Formatted PST time = %q, want %q", result, "12:00 PST")
+		}
+
+		// Verify same moment in time
+		if !pstTime.UTC().Equal(utcTime.UTC()) {
+			t.Error("Converted time doesn't represent same moment")
+		}
+	})
+
+	t.Run("from EST", func(t *testing.T) {
+		// Create 3:00 EST
+		estTime := est.Date(2024, time.January, 15, 15, 0, 0, 0)
+
+		// Convert to PST
+		pstTime := Convert(estTime)
+
+		// 3:00 PM EST = 12:00 PM PST (3 hour difference)
+		result := pstTime.Format("15:04 MST")
+		if result != "12:00 PST" {
+			t.Errorf("Formatted PST time = %q, want %q", result, "12:00 PST")
+		}
+
+		// Verify same moment in time
+		if !pstTime.UTC().Equal(estTime.UTC()) {
+			t.Error("Converted time doesn't represent same moment")
+		}
+	})
+
+	t.Run("round trip conversion", func(t *testing.T) {
+		// Create time in PST
+		original := Date(2024, time.January, 15, 10, 45, 0, 0)
+
+		// Convert to EST and back
+		viaEST := Convert(est.Convert(original))
+
+		// Should represent the same moment
+		if !viaEST.UTC().Equal(original.UTC()) {
+			t.Error("Round trip conversion changed the moment in time")
+		}
+
+		// Should format the same
+		if viaEST.Format(time.RFC3339) != original.Format(time.RFC3339) {
+			t.Errorf("Round trip format = %q, want %q",
+				viaEST.Format(time.RFC3339), original.Format(time.RFC3339))
+		}
+	})
 }

--- a/utc/utc.go
+++ b/utc/utc.go
@@ -30,3 +30,8 @@ func Now() Time {
 func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
 	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
 }
+
+// Convert converts any Moment to UTC time.
+func Convert(m meridian.Moment) Time {
+	return meridian.FromMoment[Timezone](m)
+}


### PR DESCRIPTION
Introduces the Moment interface to enable seamless interoperability between
time.Time and meridian.Time[TZ] types, allowing timezone conversions while
preserving type safety.

Core changes:
- Add Moment interface with UTC() time.Time method
- Add UTC() method to Time[TZ] to implement Moment
- Add FromMoment[TZ] helper to create typed times from any Moment
- Add Convert(Moment) function to each timezone package (utc, est, pst)

This enables:
- Converting time.Time to timezone-specific types (e.g., utc.Convert(stdTime))
- Converting between timezone types (e.g., est.Convert(utcTime))
- Using both time.Time and meridian.Time[TZ] as Moment interface values
- Preserving the moment in time across all conversions

All conversions maintain UTC equality to ensure they represent the same
instant. The typed time is displayed in the target timezone's local time
when formatted.

Includes comprehensive tests covering:
- UTC() method behavior
- time.Time to timezone type conversions
- Conversions between different timezone types
- Round-trip conversions to verify no data loss
- Verification that converted times represent the same moment

Updated example program demonstrates timezone conversion use cases.