### PR TITLE
Add timezone code generation system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,26 @@ jobs:
             exit 1
           fi
 
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@v0.7.0  # Changed from v0.30.0
+
+      - name: Verify generated code is in sync
+        run: |
+          make generate
+          # Check for both modified and untracked files
+          if [ -n "$(git status --porcelain)" ]; then
+            echo ""
+            echo "ERROR: Generated timezone packages are out of sync with timezones.yaml"
+            echo "Please run 'make generate' and commit the changes."
+            echo ""
+            echo "Changed/new files:"
+            git status --porcelain
+            echo ""
+            echo "Diff of modified files:"
+            git diff
+            echo ""
+            echo "Untracked files/directories:"
+            git ls-files --others --exclude-standard
+            exit 1
+          fi
+

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: help test test-coverage lint build clean run-example install-tools
+.PHONY: help test test-coverage lint build clean run-example install-tools generate
 
 # Default target
 help:
 	@echo "Available targets:"
+	@echo "  make generate       - Generate timezone packages from timezones.yaml"
 	@echo "  make test           - Run tests"
 	@echo "  make test-coverage  - Run tests with coverage report"
 	@echo "  make lint           - Run linter"
@@ -38,6 +39,10 @@ clean:
 	rm -rf bin/
 	rm -f coverage.out coverage.html
 	go clean
+
+# Generate timezone packages from timezones.yaml
+generate:
+	go run ./cmd/generate-timezones
 
 # Install development tools
 install-tools:

--- a/cmd/generate-timezones/main.go
+++ b/cmd/generate-timezones/main.go
@@ -1,0 +1,439 @@
+// Package main implements a code generator for timezone packages.
+// It reads timezone definitions from timezones.yaml and generates
+// package files and tests for each timezone.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the timezones.yaml structure.
+type Config struct {
+	Timezones []TimezoneDef `yaml:"timezones"`
+}
+
+// TimezoneDef defines a single timezone.
+type TimezoneDef struct {
+	Name        string `yaml:"name"`
+	Location    string `yaml:"location"`
+	Description string `yaml:"description"`
+}
+
+// TemplateData contains all variables needed for template rendering.
+type TemplateData struct {
+	PackageName string
+	Location    string
+	Description string
+	Abbrev      string
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	fmt.Println("✓ Successfully generated all timezone packages")
+}
+
+func run() error {
+	// Read timezones.yaml
+	data, err := os.ReadFile("timezones.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to read timezones.yaml: %w", err)
+	}
+
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("failed to parse timezones.yaml: %w", err)
+	}
+
+	// Generate each timezone package
+	for _, tz := range config.Timezones {
+		if err := generateTimezone(tz); err != nil {
+			return fmt.Errorf("failed to generate %s: %w", tz.Name, err)
+		}
+		fmt.Printf("Generated %s package\n", tz.Name)
+	}
+
+	return nil
+}
+
+func generateTimezone(def TimezoneDef) error {
+	// Prepare template data
+	data := TemplateData{
+		PackageName: def.Name,
+		Location:    def.Location,
+		Description: def.Description,
+		Abbrev:      strings.ToUpper(def.Name),
+	}
+
+	// Create package directory
+	pkgDir := def.Name
+	if err := os.MkdirAll(pkgDir, 0o750); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", pkgDir, err)
+	}
+
+	// Generate package file
+	pkgFile := filepath.Join(pkgDir, def.Name+".go")
+	if err := generateFile(pkgFile, packageTemplate, data); err != nil {
+		return fmt.Errorf("failed to generate package file: %w", err)
+	}
+
+	// Generate test file
+	testFile := filepath.Join(pkgDir, def.Name+"_test.go")
+	if err := generateFile(testFile, testTemplate, data); err != nil {
+		return fmt.Errorf("failed to generate test file: %w", err)
+	}
+
+	return nil
+}
+
+func generateFile(filename string, tmpl *template.Template, data TemplateData) error {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	// Write to file first
+	if err := os.WriteFile(filename, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	// Format using goimports (handles both formatting and import ordering)
+	cmd := exec.Command("goimports", "-w", filename)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to format with goimports: %w\nOutput: %s", err, output)
+	}
+
+	return nil
+}
+
+var packageTemplate = template.Must(template.New("package").Parse(`// Package {{.PackageName}} provides {{.Description}} timezone support for meridian.
+package {{.PackageName}}
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/matthalp/go-meridian"
+)
+
+// location is the IANA timezone location, loaded once at package initialization.
+var location = mustLoadLocation("{{.Location}}")
+
+// mustLoadLocation loads a timezone location or panics if it fails.
+// This should only fail if the system's timezone database is corrupted or missing.
+func mustLoadLocation(name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		panic(fmt.Sprintf("failed to load timezone %s: %v", name, err))
+	}
+	return loc
+}
+
+// Timezone represents the {{.Description}} timezone.
+type Timezone struct{}
+
+// Location returns the IANA timezone location.
+func (Timezone) Location() *time.Location {
+	return location
+}
+
+// Time is a convenience alias for meridian.Time[Timezone].
+type Time = meridian.Time[Timezone]
+
+// Now returns the current time in this timezone.
+func Now() Time {
+	return meridian.Now[Timezone]()
+}
+
+// Date creates a new time in this timezone with the specified date and time components.
+func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
+	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
+}
+
+// FromMoment converts any Moment to {{.Abbrev}} time.
+func FromMoment(m meridian.Moment) Time {
+	return meridian.FromMoment[Timezone](m)
+}
+
+// Parse parses a formatted string and returns the time value it represents in {{.Abbrev}}.
+// The layout defines the format by showing how the reference time would be displayed.
+// Note: ParseInLocation is not needed as the location is already {{.Abbrev}}.
+func Parse(layout, value string) (Time, error) {
+	return meridian.Parse[Timezone](layout, value)
+}
+
+// Unix returns the {{.Abbrev}} time corresponding to the given Unix time,
+// sec seconds and nsec nanoseconds since January 1, 1970 UTC.
+func Unix(sec, nsec int64) Time {
+	return meridian.Unix[Timezone](sec, nsec)
+}
+
+// UnixMilli returns the {{.Abbrev}} time corresponding to the given Unix time,
+// msec milliseconds since January 1, 1970 UTC.
+func UnixMilli(msec int64) Time {
+	return meridian.UnixMilli[Timezone](msec)
+}
+
+// UnixMicro returns the {{.Abbrev}} time corresponding to the given Unix time,
+// usec microseconds since January 1, 1970 UTC.
+func UnixMicro(usec int64) Time {
+	return meridian.UnixMicro[Timezone](usec)
+}
+`))
+
+var testTemplate = template.Must(template.New("test").Parse(`package {{.PackageName}}
+
+import (
+	"testing"
+	"time"
+{{- if or (ne .PackageName "pst") (ne .PackageName "utc")}}
+
+{{- if ne .PackageName "pst"}}
+	"github.com/matthalp/go-meridian/pst"
+{{- end}}
+{{- if ne .PackageName "utc"}}
+	"github.com/matthalp/go-meridian/utc"
+{{- end}}
+{{- end}}
+)
+
+func Test{{.Abbrev}}Location(t *testing.T) {
+	var tz Timezone
+	loc := tz.Location()
+	if loc.String() != "{{.Location}}" {
+		t.Errorf("Timezone.Location() = %v, want {{.Location}}", loc.String())
+	}
+}
+
+func TestNow(t *testing.T) {
+	before := time.Now().UTC()
+	tzTime := Now()
+	after := time.Now().UTC()
+
+	// Parse back to verify it's within range
+	parsed, err := time.Parse(time.RFC3339, tzTime.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+
+	if parsed.Before(before.Add(-time.Second)) || parsed.After(after.Add(time.Second)) {
+		t.Errorf("Now() returned time outside expected range: got %v, expected between %v and %v", parsed, before, after)
+	}
+}
+
+func TestDate(t *testing.T) {
+	// Create a time: Jan 15, 2024 at noon {{.Abbrev}}
+	tzTime := Date(2024, time.January, 15, 12, 0, 0, 0)
+
+	// Format should show the time in {{.Abbrev}}
+	result := tzTime.Format("15:04 MST")
+
+	// Should show noon in {{.Abbrev}}
+	if result != "12:00 {{.Abbrev}}" {
+		t.Errorf("Format() = %q, want %q", result, "12:00 {{.Abbrev}}")
+	}
+}
+
+func TestDateWithOffset(t *testing.T) {
+	// Create a time in {{.Abbrev}} (UTC offset varies by timezone and DST)
+	// Noon {{.Abbrev}} should have corresponding UTC offset
+	tzTime := Date(2024, time.January, 1, 12, 0, 0, 0)
+
+	// Parse the formatted time and convert to UTC to verify
+	parsed, err := time.Parse(time.RFC3339, tzTime.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+	utcTime := parsed.UTC()
+
+	// Verify that the hour in {{.Abbrev}} location is 12
+	locationTime := utcTime.In(location)
+	if locationTime.Hour() != 12 {
+		t.Errorf("Date() hour in {{.Abbrev}} = %v, want 12", locationTime.Hour())
+	}
+}
+
+func TestFromMoment(t *testing.T) {
+	t.Run("from time.Time", func(t *testing.T) {
+		// Test converting from standard time.Time in UTC
+		stdTime := time.Date(2024, time.January, 15, 17, 0, 0, 0, time.UTC)
+		{{.PackageName}}Time := FromMoment(stdTime)
+
+		// Verify the conversion - should represent same moment
+		if !{{.PackageName}}Time.UTC().Equal(stdTime) {
+			t.Errorf("FromMoment(time.Time) UTC = %v, want %v", {{.PackageName}}Time.UTC(), stdTime)
+		}
+	})
+
+{{- if ne .PackageName "utc"}}
+
+	t.Run("from UTC", func(t *testing.T) {
+		// Create 17:00 UTC
+		utcTime := utc.Date(2024, time.January, 15, 17, 0, 0, 0)
+
+		// Convert to {{.Abbrev}}
+		{{.PackageName}}Time := FromMoment(utcTime)
+
+		// Verify same moment in time
+		if !{{.PackageName}}Time.UTC().Equal(utcTime.UTC()) {
+			t.Error("Converted time doesn't represent same moment")
+		}
+	})
+{{- end}}
+{{- if ne .PackageName "pst"}}
+
+	t.Run("from PST", func(t *testing.T) {
+		// Create 9:00 PST
+		pstTime := pst.Date(2024, time.January, 15, 9, 0, 0, 0)
+
+		// Convert to {{.Abbrev}}
+		{{.PackageName}}Time := FromMoment(pstTime)
+
+		// Verify same moment in time
+		if !{{.PackageName}}Time.UTC().Equal(pstTime.UTC()) {
+			t.Error("Converted time doesn't represent same moment")
+		}
+	})
+{{- end}}
+
+{{- if ne .PackageName "utc"}}
+
+	t.Run("round trip conversion", func(t *testing.T) {
+		// Create time in {{.Abbrev}}
+		original := Date(2024, time.January, 15, 14, 30, 0, 0)
+
+		// Convert to UTC and back
+		viaUTC := FromMoment(utc.FromMoment(original))
+
+		// Should represent the same moment
+		if !viaUTC.UTC().Equal(original.UTC()) {
+			t.Error("Round trip conversion changed the moment in time")
+		}
+
+		// Should format the same
+		if viaUTC.Format(time.RFC3339) != original.Format(time.RFC3339) {
+			t.Errorf("Round trip format = %q, want %q",
+				viaUTC.Format(time.RFC3339), original.Format(time.RFC3339))
+		}
+	})
+{{- end}}
+}
+
+func TestParse(t *testing.T) {
+	t.Run("RFC3339 format", func(t *testing.T) {
+		// Parse a time string without timezone, should be interpreted as {{.Abbrev}}
+		parsed, err := Parse("2006-01-02 15:04:05", "2024-01-15 12:00:00")
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+
+		// Should be interpreted as 12:00 {{.Abbrev}}
+		expected := Date(2024, time.January, 15, 12, 0, 0, 0)
+		if parsed.Format(time.RFC3339) != expected.Format(time.RFC3339) {
+			t.Errorf("Parse() = %v, want %v", parsed.Format(time.RFC3339), expected.Format(time.RFC3339))
+		}
+	})
+
+{{- if ne .PackageName "utc"}}
+
+	t.Run("timezone specific interpretation", func(t *testing.T) {
+		// Parse same clock time in {{.Abbrev}}
+		{{.PackageName}}Parsed, err := Parse("2006-01-02 15:04:05", "2024-01-15 12:00:00")
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+
+		// Same clock time parsed in UTC would be different
+		utcParsed, err := utc.Parse("2006-01-02 15:04:05", "2024-01-15 12:00:00")
+		if err != nil {
+			t.Fatalf("utc.Parse() error = %v", err)
+		}
+
+		// They should represent different moments in time
+		if {{.PackageName}}Parsed.UTC().Equal(utcParsed.UTC()) {
+			t.Error("{{.Abbrev}} and UTC parse of same clock time should be different moments")
+		}
+	})
+{{- end}}
+
+	t.Run("invalid format", func(t *testing.T) {
+		_, err := Parse(time.RFC3339, "invalid-time-string")
+		if err == nil {
+			t.Error("Parse() expected error for invalid input, got nil")
+		}
+	})
+}
+
+func TestUnix(t *testing.T) {
+	t.Run("epoch", func(t *testing.T) {
+		epoch := Unix(0, 0)
+		
+		// But UTC should be epoch
+		if !epoch.UTC().Equal(time.Unix(0, 0)) {
+			t.Error("Unix(0, 0) UTC time should be epoch")
+		}
+	})
+
+	t.Run("known timestamp", func(t *testing.T) {
+		// 2024-01-15 12:00:00 UTC
+		result := Unix(1705320000, 0)
+		
+		// Verify UTC equivalence
+		if !result.UTC().Equal(time.Unix(1705320000, 0)) {
+			t.Error("Unix timestamp doesn't match")
+		}
+	})
+}
+
+func TestUnixMilli(t *testing.T) {
+	t.Run("known millisecond timestamp", func(t *testing.T) {
+		// 2024-01-15 12:00:00.000 UTC
+		msec := int64(1705320000000)
+		result := UnixMilli(msec)
+		
+		// Verify UTC equivalence
+		if !result.UTC().Equal(time.UnixMilli(msec)) {
+			t.Error("UnixMilli UTC time doesn't match")
+		}
+	})
+
+	t.Run("with milliseconds precision", func(t *testing.T) {
+		msec := int64(1705320000123)
+		result := UnixMilli(msec)
+		if !result.UTC().Equal(time.UnixMilli(msec)) {
+			t.Errorf("UnixMilli precision mismatch")
+		}
+	})
+}
+
+func TestUnixMicro(t *testing.T) {
+	t.Run("known microsecond timestamp", func(t *testing.T) {
+		// 2024-01-15 12:00:00.000000 UTC
+		usec := int64(1705320000000000)
+		result := UnixMicro(usec)
+		
+		// Verify UTC equivalence
+		if !result.UTC().Equal(time.UnixMicro(usec)) {
+			t.Error("UnixMicro UTC time doesn't match")
+		}
+	})
+
+	t.Run("with microseconds precision", func(t *testing.T) {
+		usec := int64(1705320000123456)
+		result := UnixMicro(usec)
+		if !result.UTC().Equal(time.UnixMicro(usec)) {
+			t.Errorf("UnixMicro precision mismatch")
+		}
+	})
+}
+`))

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/matthalp/go-meridian
 
 go 1.20
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/timezones.yaml
+++ b/timezones.yaml
@@ -1,0 +1,16 @@
+# Timezone definitions for go-meridian
+# Add new timezones here and run `make generate` to create the packages
+
+timezones:
+  - name: est
+    location: America/New_York
+    description: Eastern Standard Time
+  
+  - name: pst
+    location: America/Los_Angeles
+    description: Pacific Standard Time
+  
+  - name: utc
+    location: UTC
+    description: Coordinated Universal Time
+

--- a/utc/utc.go
+++ b/utc/utc.go
@@ -2,13 +2,24 @@
 package utc
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/matthalp/go-meridian"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.
-var location = time.UTC
+var location = mustLoadLocation("UTC")
+
+// mustLoadLocation loads a timezone location or panics if it fails.
+// This should only fail if the system's timezone database is corrupted or missing.
+func mustLoadLocation(name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		panic(fmt.Sprintf("failed to load timezone %s: %v", name, err))
+	}
+	return loc
+}
 
 // Timezone represents the Coordinated Universal Time timezone.
 type Timezone struct{}
@@ -38,6 +49,7 @@ func FromMoment(m meridian.Moment) Time {
 
 // Parse parses a formatted string and returns the time value it represents in UTC.
 // The layout defines the format by showing how the reference time would be displayed.
+// Note: ParseInLocation is not needed as the location is already UTC.
 func Parse(layout, value string) (Time, error) {
 	return meridian.Parse[Timezone](layout, value)
 }

--- a/utc/utc_test.go
+++ b/utc/utc_test.go
@@ -4,15 +4,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/est"
 	"github.com/matthalp/go-meridian/pst"
 )
 
 func TestUTCLocation(t *testing.T) {
 	var tz Timezone
 	loc := tz.Location()
-	if loc != time.UTC {
-		t.Errorf("Timezone.Location() = %v, want %v", loc, time.UTC)
+	if loc.String() != "UTC" {
+		t.Errorf("Timezone.Location() = %v, want UTC", loc.String())
 	}
 }
 
@@ -21,7 +20,6 @@ func TestNow(t *testing.T) {
 	tzTime := Now()
 	after := time.Now().UTC()
 
-	// Format to get the underlying time for comparison
 	// Parse back to verify it's within range
 	parsed, err := time.Parse(time.RFC3339, tzTime.Format(time.RFC3339))
 	if err != nil {
@@ -34,152 +32,75 @@ func TestNow(t *testing.T) {
 }
 
 func TestDate(t *testing.T) {
-	tests := []struct {
-		name     string
-		year     int
-		month    time.Month
-		day      int
-		hour     int
-		min      int
-		sec      int
-		nsec     int
-		expected string
-	}{
-		{
-			name:     "midnight on New Year 2024",
-			year:     2024,
-			month:    time.January,
-			day:      1,
-			hour:     0,
-			min:      0,
-			sec:      0,
-			nsec:     0,
-			expected: "2024-01-01T00:00:00Z",
-		},
-		{
-			name:     "noon",
-			year:     2024,
-			month:    time.June,
-			day:      15,
-			hour:     12,
-			min:      30,
-			sec:      45,
-			nsec:     0,
-			expected: "2024-06-15T12:30:45Z",
-		},
-	}
+	// Create a time: Jan 15, 2024 at noon UTC
+	tzTime := Date(2024, time.January, 15, 12, 0, 0, 0)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tzTime := Date(tt.year, tt.month, tt.day, tt.hour, tt.min, tt.sec, tt.nsec)
-			result := tzTime.Format(time.RFC3339)
-			if result != tt.expected {
-				t.Errorf("Date() formatted as %q, want %q", result, tt.expected)
-			}
-		})
+	// Format should show the time in UTC
+	result := tzTime.Format("15:04 MST")
+
+	// Should show noon in UTC
+	if result != "12:00 UTC" {
+		t.Errorf("Format() = %q, want %q", result, "12:00 UTC")
+	}
+}
+
+func TestDateWithOffset(t *testing.T) {
+	// Create a time in UTC (UTC offset varies by timezone and DST)
+	// Noon UTC should have corresponding UTC offset
+	tzTime := Date(2024, time.January, 1, 12, 0, 0, 0)
+
+	// Parse the formatted time and convert to UTC to verify
+	parsed, err := time.Parse(time.RFC3339, tzTime.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+	utcTime := parsed.UTC()
+
+	// Verify that the hour in UTC location is 12
+	locationTime := utcTime.In(location)
+	if locationTime.Hour() != 12 {
+		t.Errorf("Date() hour in UTC = %v, want 12", locationTime.Hour())
 	}
 }
 
 func TestFromMoment(t *testing.T) {
 	t.Run("from time.Time", func(t *testing.T) {
-		// Test converting from standard time.Time
-		stdTime := time.Date(2024, time.January, 15, 12, 0, 0, 0, time.UTC)
+		// Test converting from standard time.Time in UTC
+		stdTime := time.Date(2024, time.January, 15, 17, 0, 0, 0, time.UTC)
 		utcTime := FromMoment(stdTime)
 
-		// Verify the conversion
+		// Verify the conversion - should represent same moment
 		if !utcTime.UTC().Equal(stdTime) {
-			t.Errorf("FromMoment(time.Time) = %v, want %v", utcTime.UTC(), stdTime)
-		}
-
-		// Verify formatting shows UTC
-		result := utcTime.Format("15:04 MST")
-		if result != "12:00 UTC" {
-			t.Errorf("Formatted time = %q, want %q", result, "12:00 UTC")
-		}
-	})
-
-	t.Run("from EST", func(t *testing.T) {
-		// Create noon EST
-		estTime := est.Date(2024, time.January, 15, 12, 0, 0, 0)
-
-		// Convert to UTC
-		utcTime := FromMoment(estTime)
-
-		// 12:00 EST = 17:00 UTC in winter
-		expected := time.Date(2024, time.January, 15, 17, 0, 0, 0, time.UTC)
-		if !utcTime.UTC().Equal(expected) {
-			t.Errorf("FromMoment(EST) = %v, want %v", utcTime.UTC(), expected)
-		}
-
-		// Verify it displays as UTC
-		result := utcTime.Format("15:04 MST")
-		if result != "17:00 UTC" {
-			t.Errorf("Formatted UTC time = %q, want %q", result, "17:00 UTC")
+			t.Errorf("FromMoment(time.Time) UTC = %v, want %v", utcTime.UTC(), stdTime)
 		}
 	})
 
 	t.Run("from PST", func(t *testing.T) {
-		// Create noon PST
-		pstTime := pst.Date(2024, time.January, 15, 12, 0, 0, 0)
+		// Create 9:00 PST
+		pstTime := pst.Date(2024, time.January, 15, 9, 0, 0, 0)
 
 		// Convert to UTC
 		utcTime := FromMoment(pstTime)
 
-		// 12:00 PST = 20:00 UTC in winter
-		expected := time.Date(2024, time.January, 15, 20, 0, 0, 0, time.UTC)
-		if !utcTime.UTC().Equal(expected) {
-			t.Errorf("FromMoment(PST) = %v, want %v", utcTime.UTC(), expected)
-		}
-
-		// Verify it displays as UTC
-		result := utcTime.Format("15:04 MST")
-		if result != "20:00 UTC" {
-			t.Errorf("Formatted UTC time = %q, want %q", result, "20:00 UTC")
-		}
-	})
-
-	t.Run("preserves moment in time", func(t *testing.T) {
-		// All these should represent the same moment
-		estTime := est.Date(2024, time.January, 15, 12, 0, 0, 0)
-		pstTime := pst.Date(2024, time.January, 15, 9, 0, 0, 0) // 3 hours earlier
-		utcTime := Date(2024, time.January, 15, 17, 0, 0, 0)    // EST + 5 hours
-
-		// Convert all to UTC
-		utcFromEST := FromMoment(estTime)
-		utcFromPST := FromMoment(pstTime)
-
-		// All should be equal
-		if !utcFromEST.UTC().Equal(utcTime.UTC()) {
-			t.Error("EST conversion doesn't match expected UTC time")
-		}
-		if !utcFromPST.UTC().Equal(utcTime.UTC()) {
-			t.Error("PST conversion doesn't match expected UTC time")
+		// Verify same moment in time
+		if !utcTime.UTC().Equal(pstTime.UTC()) {
+			t.Error("Converted time doesn't represent same moment")
 		}
 	})
 }
 
 func TestParse(t *testing.T) {
 	t.Run("RFC3339 format", func(t *testing.T) {
-		parsed, err := Parse(time.RFC3339, "2024-01-15T12:00:00Z")
-		if err != nil {
-			t.Fatalf("Parse() error = %v", err)
-		}
-
-		expected := Date(2024, time.January, 15, 12, 0, 0, 0)
-		if parsed.Format(time.RFC3339) != expected.Format(time.RFC3339) {
-			t.Errorf("Parse() = %v, want %v", parsed.Format(time.RFC3339), expected.Format(time.RFC3339))
-		}
-	})
-
-	t.Run("custom format", func(t *testing.T) {
+		// Parse a time string without timezone, should be interpreted as UTC
 		parsed, err := Parse("2006-01-02 15:04:05", "2024-01-15 12:00:00")
 		if err != nil {
 			t.Fatalf("Parse() error = %v", err)
 		}
 
-		result := parsed.Format("2006-01-02 15:04:05")
-		if result != "2024-01-15 12:00:00" {
-			t.Errorf("Parse() formatted = %v, want %v", result, "2024-01-15 12:00:00")
+		// Should be interpreted as 12:00 UTC
+		expected := Date(2024, time.January, 15, 12, 0, 0, 0)
+		if parsed.Format(time.RFC3339) != expected.Format(time.RFC3339) {
+			t.Errorf("Parse() = %v, want %v", parsed.Format(time.RFC3339), expected.Format(time.RFC3339))
 		}
 	})
 
@@ -194,26 +115,20 @@ func TestParse(t *testing.T) {
 func TestUnix(t *testing.T) {
 	t.Run("epoch", func(t *testing.T) {
 		epoch := Unix(0, 0)
-		expected := "1970-01-01T00:00:00Z"
-		if epoch.Format(time.RFC3339) != expected {
-			t.Errorf("Unix(0, 0) = %v, want %v", epoch.Format(time.RFC3339), expected)
+
+		// But UTC should be epoch
+		if !epoch.UTC().Equal(time.Unix(0, 0)) {
+			t.Error("Unix(0, 0) UTC time should be epoch")
 		}
 	})
 
 	t.Run("known timestamp", func(t *testing.T) {
 		// 2024-01-15 12:00:00 UTC
 		result := Unix(1705320000, 0)
-		expected := "2024-01-15T12:00:00Z"
-		if result.Format(time.RFC3339) != expected {
-			t.Errorf("Unix(1705320000, 0) = %v, want %v", result.Format(time.RFC3339), expected)
-		}
-	})
 
-	t.Run("with nanoseconds", func(t *testing.T) {
-		result := Unix(1705320000, 500000000)
-		// Should be 12:00:00.5
-		if !result.UTC().Equal(time.Unix(1705320000, 500000000)) {
-			t.Errorf("Unix with nanoseconds didn't match expected time")
+		// Verify UTC equivalence
+		if !result.UTC().Equal(time.Unix(1705320000, 0)) {
+			t.Error("Unix timestamp doesn't match")
 		}
 	})
 }
@@ -223,18 +138,17 @@ func TestUnixMilli(t *testing.T) {
 		// 2024-01-15 12:00:00.000 UTC
 		msec := int64(1705320000000)
 		result := UnixMilli(msec)
-		expected := "2024-01-15T12:00:00Z"
-		if result.Format(time.RFC3339) != expected {
-			t.Errorf("UnixMilli(%d) = %v, want %v", msec, result.Format(time.RFC3339), expected)
+
+		// Verify UTC equivalence
+		if !result.UTC().Equal(time.UnixMilli(msec)) {
+			t.Error("UnixMilli UTC time doesn't match")
 		}
 	})
 
 	t.Run("with milliseconds precision", func(t *testing.T) {
-		// 2024-01-15 12:00:00.123 UTC
 		msec := int64(1705320000123)
 		result := UnixMilli(msec)
-		stdTime := time.UnixMilli(msec)
-		if !result.UTC().Equal(stdTime) {
+		if !result.UTC().Equal(time.UnixMilli(msec)) {
 			t.Errorf("UnixMilli precision mismatch")
 		}
 	})
@@ -245,18 +159,17 @@ func TestUnixMicro(t *testing.T) {
 		// 2024-01-15 12:00:00.000000 UTC
 		usec := int64(1705320000000000)
 		result := UnixMicro(usec)
-		expected := "2024-01-15T12:00:00Z"
-		if result.Format(time.RFC3339) != expected {
-			t.Errorf("UnixMicro(%d) = %v, want %v", usec, result.Format(time.RFC3339), expected)
+
+		// Verify UTC equivalence
+		if !result.UTC().Equal(time.UnixMicro(usec)) {
+			t.Error("UnixMicro UTC time doesn't match")
 		}
 	})
 
 	t.Run("with microseconds precision", func(t *testing.T) {
-		// 2024-01-15 12:00:00.123456 UTC
 		usec := int64(1705320000123456)
 		result := UnixMicro(usec)
-		stdTime := time.UnixMicro(usec)
-		if !result.UTC().Equal(stdTime) {
+		if !result.UTC().Equal(time.UnixMicro(usec)) {
 			t.Errorf("UnixMicro precision mismatch")
 		}
 	})


### PR DESCRIPTION
- Create timezones.yaml for defining timezones
- Add cmd/generate-timezones/ tool to generate timezone packages
- Add 'make generate' command to regenerate packages
- Add CI check to verify generated code is in sync
- Update AGENTS.md with new timezone addition workflow
- Add gopkg.in/yaml.v3 dependency for YAML parsing

Timezone packages (est, pst, utc) are now generated from YAML
configuration, eliminating copy-paste errors and making it trivial
to add new timezones. The CI pipeline verifies that generated code
stays in sync with the configuration file.