### PR TITLE
Add generic factory methods and rename Convert to FromMoment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ This is a **distributable library** intended for consumption by other Go project
 - Package name conveys timezone, type is always `Timezone`
 
 ### 3. Explicit Conversions
-- Timezone conversions must be explicit: `est.Convert(pacificTime)`
+- Timezone conversions must be explicit: `est.FromMoment(pacificTime)`
 - Conversions use the `Moment` interface, supporting both `time.Time` and `meridian.Time[TZ]`
 - This makes timezone handling visible in code review
 - No silent timezone changes or data loss
@@ -178,22 +178,22 @@ microTime := est.UnixMicro(1705320000000000)  // microseconds
 
 // From standard time.Time
 stdTime := time.Now()
-typed := utc.Convert(stdTime)  // Convert using Moment interface
+typed := utc.FromMoment(stdTime)  // Convert using Moment interface
 ```
 
 **Note**: `ParseInLocation` from the `time` package is not needed in timezone packages because the location is already determined by the package (e.g., `utc.Parse` always parses in UTC, `est.Parse` in EST, `pst.Parse` in PST).
 
 ### Converting Between Timezones
 ```go
-// Using timezone package Convert functions
+// Using timezone package FromMoment functions
 eastern := est.Now()
-pacific := pst.Convert(eastern)  // Explicit conversion
-utcTime := utc.Convert(eastern)  // To UTC for storage
+pacific := pst.FromMoment(eastern)  // Explicit conversion
+utcTime := utc.FromMoment(eastern)  // To UTC for storage
 
 // Convert from time.Time
 stdTime := time.Now()
-utcTyped := utc.Convert(stdTime)
-estTyped := est.Convert(stdTime)
+utcTyped := utc.FromMoment(stdTime)
+estTyped := est.FromMoment(stdTime)
 
 // All conversions preserve the moment in time
 fmt.Println(eastern.UTC().Equal(pacific.UTC()))  // true
@@ -263,12 +263,12 @@ func GetUTC[TZ Timezone](t Time[TZ]) time.Time {
 ```go
 // Good: Explicit conversion to UTC type
 func GetUTC[TZ Timezone](t Time[TZ]) utc.Time {
-    return utc.Convert(t)
+    return utc.FromMoment(t)
 }
 
 // Or use the Moment interface for flexibility
 func GetUTC(m Moment) utc.Time {
-    return utc.Convert(m)
+    return utc.FromMoment(m)
 }
 ```
 
@@ -392,9 +392,9 @@ func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
     return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
 }
 
-// Convert converts any Moment to JST time.
-func Convert(m meridian.Moment) Time {
-    return meridian.FromMoment[Timezone](m)
+// FromMoment converts any Moment to JST time.
+func FromMoment(m meridian.Moment) Time {
+	return meridian.FromMoment[Timezone](m)
 }
 
 // Parse parses a formatted string and returns the time value it represents in JST.
@@ -433,7 +433,7 @@ func UnixMicro(usec int64) Time {
 - Location loaded once at init in a package variable for efficiency
 - `mustLoadLocation` helper panics early if timezone database is missing
 - Consistent comments and structure across all timezone packages
-- All factory methods (Now, Date, Parse, Unix, UnixMilli, UnixMicro, Convert) follow the same pattern
+- All factory methods (Now, Date, Parse, Unix, UnixMilli, UnixMicro, FromMoment) follow the same pattern
 
 ## Questions to Ask Before Committing
 

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -50,8 +50,8 @@ func main() {
 	// Example 5: Converting between timezones
 	fmt.Println("5. Timezone Conversion:")
 	estMeeting := est.Date(2024, time.December, 25, 10, 30, 0, 0)
-	utcMeeting := utc.Convert(estMeeting)
-	pstMeeting := pst.Convert(estMeeting)
+	utcMeeting := utc.FromMoment(estMeeting)
+	pstMeeting := pst.FromMoment(estMeeting)
 
 	fmt.Printf("   Meeting EST: %s\n", estMeeting.Format(time.Kitchen))
 	fmt.Printf("   Meeting UTC: %s\n", utcMeeting.Format(time.Kitchen))
@@ -64,9 +64,9 @@ func main() {
 	fmt.Printf("   Standard time.Time: %s\n", stdTime.Format(time.RFC3339))
 
 	// Convert to timezone-specific types
-	utcFromStd := utc.Convert(stdTime)
-	estFromStd := est.Convert(stdTime)
-	pstFromStd := pst.Convert(stdTime)
+	utcFromStd := utc.FromMoment(stdTime)
+	estFromStd := est.FromMoment(stdTime)
+	pstFromStd := pst.FromMoment(stdTime)
 
 	fmt.Printf("   As UTC: %s\n", utcFromStd.Format("3:04 PM MST"))
 	fmt.Printf("   As EST: %s\n", estFromStd.Format("3:04 PM MST"))

--- a/est/est.go
+++ b/est/est.go
@@ -42,8 +42,8 @@ func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
 	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
 }
 
-// Convert converts any Moment to EST time.
-func Convert(m meridian.Moment) Time {
+// FromMoment converts any Moment to EST time.
+func FromMoment(m meridian.Moment) Time {
 	return meridian.FromMoment[Timezone](m)
 }
 
@@ -51,27 +51,23 @@ func Convert(m meridian.Moment) Time {
 // The layout defines the format by showing how the reference time would be displayed.
 // Note: ParseInLocation is not needed as the location is already EST.
 func Parse(layout, value string) (Time, error) {
-	t, err := time.ParseInLocation(layout, value, location)
-	if err != nil {
-		return Time{}, err
-	}
-	return meridian.FromMoment[Timezone](t), nil
+	return meridian.Parse[Timezone](layout, value)
 }
 
 // Unix returns the EST time corresponding to the given Unix time,
 // sec seconds and nsec nanoseconds since January 1, 1970 UTC.
 func Unix(sec, nsec int64) Time {
-	return meridian.FromMoment[Timezone](time.Unix(sec, nsec))
+	return meridian.Unix[Timezone](sec, nsec)
 }
 
 // UnixMilli returns the EST time corresponding to the given Unix time,
 // msec milliseconds since January 1, 1970 UTC.
 func UnixMilli(msec int64) Time {
-	return meridian.FromMoment[Timezone](time.UnixMilli(msec))
+	return meridian.UnixMilli[Timezone](msec)
 }
 
 // UnixMicro returns the EST time corresponding to the given Unix time,
 // usec microseconds since January 1, 1970 UTC.
 func UnixMicro(usec int64) Time {
-	return meridian.FromMoment[Timezone](time.UnixMicro(usec))
+	return meridian.UnixMicro[Timezone](usec)
 }

--- a/est/est_test.go
+++ b/est/est_test.go
@@ -65,15 +65,15 @@ func TestDateWithOffset(t *testing.T) {
 	}
 }
 
-func TestConvert(t *testing.T) {
+func TestFromMoment(t *testing.T) {
 	t.Run("from time.Time", func(t *testing.T) {
 		// Test converting from standard time.Time in UTC
 		stdTime := time.Date(2024, time.January, 15, 17, 0, 0, 0, time.UTC)
-		estTime := Convert(stdTime)
+		estTime := FromMoment(stdTime)
 
 		// Verify the conversion - should represent same moment
 		if !estTime.UTC().Equal(stdTime) {
-			t.Errorf("Convert(time.Time) UTC = %v, want %v", estTime.UTC(), stdTime)
+			t.Errorf("FromMoment(time.Time) UTC = %v, want %v", estTime.UTC(), stdTime)
 		}
 
 		// Verify formatting shows EST (17:00 UTC = 12:00 EST)
@@ -88,7 +88,7 @@ func TestConvert(t *testing.T) {
 		utcTime := utc.Date(2024, time.January, 15, 17, 0, 0, 0)
 
 		// Convert to EST
-		estTime := Convert(utcTime)
+		estTime := FromMoment(utcTime)
 
 		// 17:00 UTC = 12:00 EST in winter
 		result := estTime.Format("15:04 MST")
@@ -107,7 +107,7 @@ func TestConvert(t *testing.T) {
 		pstTime := pst.Date(2024, time.January, 15, 9, 0, 0, 0)
 
 		// Convert to EST
-		estTime := Convert(pstTime)
+		estTime := FromMoment(pstTime)
 
 		// 9:00 PST = 12:00 EST (3 hour difference)
 		result := estTime.Format("15:04 MST")
@@ -126,7 +126,7 @@ func TestConvert(t *testing.T) {
 		original := Date(2024, time.January, 15, 14, 30, 0, 0)
 
 		// Convert to UTC and back
-		viaUTC := Convert(utc.Convert(original))
+		viaUTC := FromMoment(utc.FromMoment(original))
 
 		// Should represent the same moment
 		if !viaUTC.UTC().Equal(original.UTC()) {

--- a/meridian.go
+++ b/meridian.go
@@ -43,6 +43,36 @@ func FromMoment[TZ Timezone](m Moment) Time[TZ] {
 	return Time[TZ]{utcTime: m.UTC()}
 }
 
+// Parse parses a formatted string and returns the time value it represents in the specified timezone.
+// The layout defines the format by showing how the reference time would be displayed.
+func Parse[TZ Timezone](layout, value string) (Time[TZ], error) {
+	loc := getLocation[TZ]()
+	t, err := time.ParseInLocation(layout, value, loc)
+	if err != nil {
+		return Time[TZ]{}, err
+	}
+	return Time[TZ]{utcTime: t.UTC()}, nil
+}
+
+// Unix returns the Time corresponding to the given Unix time,
+// sec seconds and nsec nanoseconds since January 1, 1970 UTC,
+// in the specified timezone.
+func Unix[TZ Timezone](sec, nsec int64) Time[TZ] {
+	return Time[TZ]{utcTime: time.Unix(sec, nsec).UTC()}
+}
+
+// UnixMilli returns the Time corresponding to the given Unix time,
+// msec milliseconds since January 1, 1970 UTC, in the specified timezone.
+func UnixMilli[TZ Timezone](msec int64) Time[TZ] {
+	return Time[TZ]{utcTime: time.UnixMilli(msec).UTC()}
+}
+
+// UnixMicro returns the Time corresponding to the given Unix time,
+// usec microseconds since January 1, 1970 UTC, in the specified timezone.
+func UnixMicro[TZ Timezone](usec int64) Time[TZ] {
+	return Time[TZ]{utcTime: time.UnixMicro(usec).UTC()}
+}
+
 // getLocation extracts the *time.Location from a timezone type.
 func getLocation[TZ Timezone]() *time.Location {
 	var tz TZ

--- a/pst/pst.go
+++ b/pst/pst.go
@@ -42,8 +42,8 @@ func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
 	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
 }
 
-// Convert converts any Moment to PST time.
-func Convert(m meridian.Moment) Time {
+// FromMoment converts any Moment to PST time.
+func FromMoment(m meridian.Moment) Time {
 	return meridian.FromMoment[Timezone](m)
 }
 
@@ -51,27 +51,23 @@ func Convert(m meridian.Moment) Time {
 // The layout defines the format by showing how the reference time would be displayed.
 // Note: ParseInLocation is not needed as the location is already PST.
 func Parse(layout, value string) (Time, error) {
-	t, err := time.ParseInLocation(layout, value, location)
-	if err != nil {
-		return Time{}, err
-	}
-	return meridian.FromMoment[Timezone](t), nil
+	return meridian.Parse[Timezone](layout, value)
 }
 
 // Unix returns the PST time corresponding to the given Unix time,
 // sec seconds and nsec nanoseconds since January 1, 1970 UTC.
 func Unix(sec, nsec int64) Time {
-	return meridian.FromMoment[Timezone](time.Unix(sec, nsec))
+	return meridian.Unix[Timezone](sec, nsec)
 }
 
 // UnixMilli returns the PST time corresponding to the given Unix time,
 // msec milliseconds since January 1, 1970 UTC.
 func UnixMilli(msec int64) Time {
-	return meridian.FromMoment[Timezone](time.UnixMilli(msec))
+	return meridian.UnixMilli[Timezone](msec)
 }
 
 // UnixMicro returns the PST time corresponding to the given Unix time,
 // usec microseconds since January 1, 1970 UTC.
 func UnixMicro(usec int64) Time {
-	return meridian.FromMoment[Timezone](time.UnixMicro(usec))
+	return meridian.UnixMicro[Timezone](usec)
 }

--- a/pst/pst_test.go
+++ b/pst/pst_test.go
@@ -65,15 +65,15 @@ func TestDateWithOffset(t *testing.T) {
 	}
 }
 
-func TestConvert(t *testing.T) {
+func TestFromMoment(t *testing.T) {
 	t.Run("from time.Time", func(t *testing.T) {
 		// Test converting from standard time.Time in UTC
 		stdTime := time.Date(2024, time.January, 15, 20, 0, 0, 0, time.UTC)
-		pstTime := Convert(stdTime)
+		pstTime := FromMoment(stdTime)
 
 		// Verify the conversion - should represent same moment
 		if !pstTime.UTC().Equal(stdTime) {
-			t.Errorf("Convert(time.Time) UTC = %v, want %v", pstTime.UTC(), stdTime)
+			t.Errorf("FromMoment(time.Time) UTC = %v, want %v", pstTime.UTC(), stdTime)
 		}
 
 		// Verify formatting shows PST (20:00 UTC = 12:00 PST)
@@ -88,7 +88,7 @@ func TestConvert(t *testing.T) {
 		utcTime := utc.Date(2024, time.January, 15, 20, 0, 0, 0)
 
 		// Convert to PST
-		pstTime := Convert(utcTime)
+		pstTime := FromMoment(utcTime)
 
 		// 20:00 UTC = 12:00 PST in winter
 		result := pstTime.Format("15:04 MST")
@@ -107,7 +107,7 @@ func TestConvert(t *testing.T) {
 		estTime := est.Date(2024, time.January, 15, 15, 0, 0, 0)
 
 		// Convert to PST
-		pstTime := Convert(estTime)
+		pstTime := FromMoment(estTime)
 
 		// 3:00 PM EST = 12:00 PM PST (3 hour difference)
 		result := pstTime.Format("15:04 MST")
@@ -126,7 +126,7 @@ func TestConvert(t *testing.T) {
 		original := Date(2024, time.January, 15, 10, 45, 0, 0)
 
 		// Convert to EST and back
-		viaEST := Convert(est.Convert(original))
+		viaEST := FromMoment(est.FromMoment(original))
 
 		// Should represent the same moment
 		if !viaEST.UTC().Equal(original.UTC()) {

--- a/utc/utc.go
+++ b/utc/utc.go
@@ -31,35 +31,31 @@ func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
 	return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
 }
 
-// Convert converts any Moment to UTC time.
-func Convert(m meridian.Moment) Time {
+// FromMoment converts any Moment to UTC time.
+func FromMoment(m meridian.Moment) Time {
 	return meridian.FromMoment[Timezone](m)
 }
 
 // Parse parses a formatted string and returns the time value it represents in UTC.
 // The layout defines the format by showing how the reference time would be displayed.
 func Parse(layout, value string) (Time, error) {
-	t, err := time.Parse(layout, value)
-	if err != nil {
-		return Time{}, err
-	}
-	return meridian.FromMoment[Timezone](t), nil
+	return meridian.Parse[Timezone](layout, value)
 }
 
 // Unix returns the UTC time corresponding to the given Unix time,
 // sec seconds and nsec nanoseconds since January 1, 1970 UTC.
 func Unix(sec, nsec int64) Time {
-	return meridian.FromMoment[Timezone](time.Unix(sec, nsec))
+	return meridian.Unix[Timezone](sec, nsec)
 }
 
 // UnixMilli returns the UTC time corresponding to the given Unix time,
 // msec milliseconds since January 1, 1970 UTC.
 func UnixMilli(msec int64) Time {
-	return meridian.FromMoment[Timezone](time.UnixMilli(msec))
+	return meridian.UnixMilli[Timezone](msec)
 }
 
 // UnixMicro returns the UTC time corresponding to the given Unix time,
 // usec microseconds since January 1, 1970 UTC.
 func UnixMicro(usec int64) Time {
-	return meridian.FromMoment[Timezone](time.UnixMicro(usec))
+	return meridian.UnixMicro[Timezone](usec)
 }

--- a/utc/utc_test.go
+++ b/utc/utc_test.go
@@ -80,15 +80,15 @@ func TestDate(t *testing.T) {
 	}
 }
 
-func TestConvert(t *testing.T) {
+func TestFromMoment(t *testing.T) {
 	t.Run("from time.Time", func(t *testing.T) {
 		// Test converting from standard time.Time
 		stdTime := time.Date(2024, time.January, 15, 12, 0, 0, 0, time.UTC)
-		utcTime := Convert(stdTime)
+		utcTime := FromMoment(stdTime)
 
 		// Verify the conversion
 		if !utcTime.UTC().Equal(stdTime) {
-			t.Errorf("Convert(time.Time) = %v, want %v", utcTime.UTC(), stdTime)
+			t.Errorf("FromMoment(time.Time) = %v, want %v", utcTime.UTC(), stdTime)
 		}
 
 		// Verify formatting shows UTC
@@ -103,12 +103,12 @@ func TestConvert(t *testing.T) {
 		estTime := est.Date(2024, time.January, 15, 12, 0, 0, 0)
 
 		// Convert to UTC
-		utcTime := Convert(estTime)
+		utcTime := FromMoment(estTime)
 
 		// 12:00 EST = 17:00 UTC in winter
 		expected := time.Date(2024, time.January, 15, 17, 0, 0, 0, time.UTC)
 		if !utcTime.UTC().Equal(expected) {
-			t.Errorf("Convert(EST) = %v, want %v", utcTime.UTC(), expected)
+			t.Errorf("FromMoment(EST) = %v, want %v", utcTime.UTC(), expected)
 		}
 
 		// Verify it displays as UTC
@@ -123,12 +123,12 @@ func TestConvert(t *testing.T) {
 		pstTime := pst.Date(2024, time.January, 15, 12, 0, 0, 0)
 
 		// Convert to UTC
-		utcTime := Convert(pstTime)
+		utcTime := FromMoment(pstTime)
 
 		// 12:00 PST = 20:00 UTC in winter
 		expected := time.Date(2024, time.January, 15, 20, 0, 0, 0, time.UTC)
 		if !utcTime.UTC().Equal(expected) {
-			t.Errorf("Convert(PST) = %v, want %v", utcTime.UTC(), expected)
+			t.Errorf("FromMoment(PST) = %v, want %v", utcTime.UTC(), expected)
 		}
 
 		// Verify it displays as UTC
@@ -145,8 +145,8 @@ func TestConvert(t *testing.T) {
 		utcTime := Date(2024, time.January, 15, 17, 0, 0, 0)    // EST + 5 hours
 
 		// Convert all to UTC
-		utcFromEST := Convert(estTime)
-		utcFromPST := Convert(pstTime)
+		utcFromEST := FromMoment(estTime)
+		utcFromPST := FromMoment(pstTime)
 
 		// All should be equal
 		if !utcFromEST.UTC().Equal(utcTime.UTC()) {


### PR DESCRIPTION
- Add Parse[TZ], Unix[TZ], UnixMilli[TZ], UnixMicro[TZ] generic functions to meridian.go
- Update timezone packages (est, pst, utc) to call generic functions for consistency
- Rename Convert() to FromMoment() in all timezone packages for naming consistency
- Update all tests to use new FromMoment naming
- Update documentation (AGENTS.md) and examples to reflect changes