### PR TITLE
Fix AddDate to add calendar dates relative to the timezone (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nothing yet
 
 ### Fixed
-- Nothing yet
+- `Time[TZ].AddDate` now performs calendar arithmetic in the timezone's
+  location instead of UTC, preserving the wall-clock time across Daylight
+  Saving Time transitions (#29). Previously, adding a day always advanced the
+  underlying UTC instant by a literal 24 hours, which shifted the displayed
+  wall-clock time by an hour when crossing a DST boundary.
 
 ### Security
 - Nothing yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nothing yet
 
 ### Fixed
+- Nothing yet
+
+### Security
+- Nothing yet
+
+## [2.0.1] - 2026-06-07
+
+### Fixed
 - `Time[TZ].AddDate` now performs calendar arithmetic in the timezone's
   location instead of UTC, preserving the wall-clock time across Daylight
   Saving Time transitions (#29). Previously, adding a day always advanced the
   underlying UTC instant by a literal 24 hours, which shifted the displayed
   wall-clock time by an hour when crossing a DST boundary.
-
-### Security
-- Nothing yet

--- a/meridian.go
+++ b/meridian.go
@@ -230,13 +230,6 @@ func (t Time[TZ]) Add(d time.Duration) Time[TZ] {
 
 // AddDate returns the time corresponding to adding the given number of years,
 // months, and days to t, preserving the timezone type.
-//
-// The calendar arithmetic is performed in the timezone's location rather than
-// in UTC, so the wall-clock time is preserved across Daylight Saving Time
-// transitions. For example, adding one day to midnight on the day before a DST
-// "spring forward" yields midnight the next day (a 23-hour span), not 1:00 AM
-// (a literal 24-hour span). This matches the behavior of time.Time.AddDate when
-// called on a time.Time that already carries the timezone's location.
 func (t Time[TZ]) AddDate(years, months, days int) Time[TZ] {
 	return Time[TZ]{utcTime: t.nativeTimeInLocation().AddDate(years, months, days).UTC()}
 }

--- a/meridian.go
+++ b/meridian.go
@@ -230,8 +230,15 @@ func (t Time[TZ]) Add(d time.Duration) Time[TZ] {
 
 // AddDate returns the time corresponding to adding the given number of years,
 // months, and days to t, preserving the timezone type.
+//
+// The calendar arithmetic is performed in the timezone's location rather than
+// in UTC, so the wall-clock time is preserved across Daylight Saving Time
+// transitions. For example, adding one day to midnight on the day before a DST
+// "spring forward" yields midnight the next day (a 23-hour span), not 1:00 AM
+// (a literal 24-hour span). This matches the behavior of time.Time.AddDate when
+// called on a time.Time that already carries the timezone's location.
 func (t Time[TZ]) AddDate(years, months, days int) Time[TZ] {
-	return Time[TZ]{utcTime: t.utcTime.AddDate(years, months, days)}
+	return Time[TZ]{utcTime: t.nativeTimeInLocation().AddDate(years, months, days).UTC()}
 }
 
 // Sub returns the duration t-u. If the result exceeds the maximum (or minimum)

--- a/meridian.go
+++ b/meridian.go
@@ -81,7 +81,7 @@ import (
 )
 
 // Version is the current version of the meridian package.
-const Version = "2.0.0"
+const Version = "2.0.1"
 
 // Timezone interface that all timezone types must implement.
 // Each timezone package defines its own Timezone type that satisfies this interface,

--- a/meridian_test.go
+++ b/meridian_test.go
@@ -497,6 +497,60 @@ func TestAddDate(t *testing.T) {
 	}
 }
 
+// TestAddDateAcrossDST verifies that AddDate performs calendar arithmetic in the
+// timezone's location, preserving the wall-clock time across DST transitions
+// rather than always adding a literal 24 hours per day. See issue #29.
+func TestAddDateAcrossDST(t *testing.T) {
+	tests := []struct {
+		name  string
+		start Time[PST]
+		days  int
+		// Expected wall-clock components in the timezone's location.
+		wantYear  int
+		wantMonth time.Month
+		wantDay   int
+		wantHour  int
+	}{
+		{
+			// "Spring forward": 2026-03-08 02:00 PST -> 03:00 PDT.
+			// Adding one calendar day to midnight should yield midnight the
+			// next day (a 23-hour span), not 01:00.
+			name:      "spring forward preserves wall clock",
+			start:     Date[PST](2026, time.March, 8, 0, 0, 0, 0),
+			days:      1,
+			wantYear:  2026,
+			wantMonth: time.March,
+			wantDay:   9,
+			wantHour:  0,
+		},
+		{
+			// "Fall back": 2026-11-01 02:00 PDT -> 01:00 PST.
+			// Adding one calendar day to midnight should yield midnight the
+			// next day (a 25-hour span), not 23:00 of the same day.
+			name:      "fall back preserves wall clock",
+			start:     Date[PST](2026, time.November, 1, 0, 0, 0, 0),
+			days:      1,
+			wantYear:  2026,
+			wantMonth: time.November,
+			wantDay:   2,
+			wantHour:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.start.AddDate(0, 0, tt.days)
+			year, month, day := result.Date()
+			hour := result.Hour()
+			if year != tt.wantYear || month != tt.wantMonth || day != tt.wantDay || hour != tt.wantHour {
+				t.Errorf("AddDate(0, 0, %d) = %04d-%02d-%02d %02d:00, want %04d-%02d-%02d %02d:00",
+					tt.days, year, month, day, hour,
+					tt.wantYear, tt.wantMonth, tt.wantDay, tt.wantHour)
+			}
+		})
+	}
+}
+
 func TestSub(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fixes #29.

## Problem

`Time[TZ].AddDate` performed calendar arithmetic directly on the internal `utcTime`:

```go
func (t Time[TZ]) AddDate(years, months, days int) Time[TZ] {
	return Time[TZ]{utcTime: t.utcTime.AddDate(years, months, days)}
}
```

Because the value is stored in UTC, this always advances the underlying instant by a literal 24 hours per day. When the calendar interval crosses a Daylight Saving Time boundary, the displayed wall-clock time shifts by an hour — e.g. midnight + 1 day landing on 1:00 AM across "spring forward".

## Fix

Do the calendar arithmetic on the time **in the timezone's location**, then convert back to UTC — the same `nativeTimeInLocation()` approach every other component method (`Date`, `Clock`, `Hour`, …) already uses. This preserves the wall-clock time across DST transitions, which is what callers expect from a calendar operation on a timezone-typed value.

Reproduction from the issue, now matching the proposed output:

```
March DST AddDate
Start:   2026-03-08 00:00:00 -0800 PST
AddDate: 2026-03-09 00:00:00 -0700 PDT   (was 2026-03-09 01:00:00)

November DST AddDate
Start:   2026-11-01 00:00:00 -0700 PDT
AddDate: 2026-11-02 00:00:00 -0800 PST   (was 2026-11-01 23:00:00)
```

I chose to fix `AddDate` in place (rather than add a separate `AddCalendarDate`) because the library's stated philosophy is to make timezone handling correct by default, and `Time[TZ]` already interprets every other component in its location. The existing `TestAddDate` cases all use UTC and are unaffected.

## Similar issues considered

I audited the other methods that operate on `utcTime` directly for the same "civil operation done against UTC" class of bug:

- `Add`, `Sub`, `After`/`Before`/`Equal`/`Compare`, the `Unix*` accessors, and the binary/gob marshalers all operate on absolute time, where UTC is correct.
- `Round` / `Truncate` operate on absolute time since the zero time. This is intentionally documented behavior in the standard library (`time.Time.Truncate` "does not operate on the presentation form"), and the existing tests assert that semantics. I left them unchanged to stay consistent with `time.Time`; happy to revisit if you'd prefer location-aware rounding.

`AddDate` was the only method doing genuine calendar arithmetic against the wrong reference frame.

## Tests

- Added `TestAddDateAcrossDST` covering both spring-forward and fall-back boundaries in `America/Los_Angeles`.
- `go test ./...`, `go vet ./...`, and `gofmt` all pass.
- Updated `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)