### PR TITLE
Release v3.0.0: Go 1.27 + fluent To() timezone conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.27.0-rc.1'
 
       - name: Download dependencies
         run: go mod download
@@ -51,15 +51,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.27.0-rc.1'
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.54
-          args: --timeout=5m
+          # golangci-lint must be built against Go >= 1.27 to lint v3 sources
+          # (generic methods). Until a 1.27-built release ships, "latest" tracks
+          # the newest available; pin to a specific v2.x once one is published.
+          version: latest
 
   build:
     name: Build
@@ -69,9 +71,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.27.0-rc.1'
 
       - name: Download dependencies
         run: go mod download

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,58 +1,59 @@
+version: "2"
 run:
-  timeout: 5m
   tests: true
-  skip-dirs:
-    - vendor
-
 linters:
   enable:
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-    - gofmt
-    - goimports
-    - revive
-    - misspell
-    - gosec
-    - unconvert
-    - unparam
     - gocritic
     - gocyclo
     - godot
+    - gosec
+    - misspell
+    - revive
+    - unconvert
+    - unparam
     - whitespace
-
-linters-settings:
-  gocyclo:
-    min-complexity: 15
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-  revive:
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: increment-decrement
-      - name: var-naming
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: indent-error-flow
-      - name: superfluous-else
-
+  settings:
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        - name: var-naming
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: indent-error-flow
+        - name: superfluous-else
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
-
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,12 @@ This is a **distributable library** intended for consumption by other Go project
 - Package name conveys timezone, type is always `Timezone`
 
 ### 3. Explicit Conversions
-- Timezone conversions must be explicit: `est.FromMoment(pacificTime)`
+- Timezone conversions must be explicit. Two equivalent forms exist:
+  - Method form (preferred for `Time` → `Time`): `eastern.To[pt.Timezone]()`
+  - Package-function form (required for plain `time.Time`): `pt.FromMoment(eastern)`
+- The `To` method is a generic method (`func (t Time[TZ]) To[TZ2 Timezone]() Time[TZ2]`),
+  a Go 1.27 language feature. It cannot start from a `time.Time` (no method), so
+  `FromMoment` remains for that case.
 - Conversions use the `Moment` interface, supporting both `time.Time` and `meridian.Time[TZ]`
 - This makes timezone handling visible in code review
 - No silent timezone changes or data loss
@@ -153,8 +158,8 @@ import (
     // External dependencies (none currently)
     
     // Internal packages
-    "github.com/matthalp/go-meridian"
-    "github.com/matthalp/go-meridian/est"
+    "github.com/matthalp/go-meridian/v3"
+    "github.com/matthalp/go-meridian/v3/timezones/est"
 )
 ```
 
@@ -185,10 +190,14 @@ typed := utc.FromMoment(stdTime)  // Convert using Moment interface
 
 ### Converting Between Timezones
 ```go
-// Using timezone package FromMoment functions
+// Method form (Go 1.27 generic methods) — preferred for Time -> Time
 eastern := est.Now()
-pacific := pst.FromMoment(eastern)  // Explicit conversion
-utcTime := utc.FromMoment(eastern)  // To UTC for storage
+pacific := eastern.To[pst.Timezone]()  // Explicit conversion
+utcTime := eastern.To[utc.Timezone]()  // To UTC for storage
+
+// Equivalent package-function form (also works for plain time.Time)
+pacific = pst.FromMoment(eastern)
+utcTime = utc.FromMoment(eastern)
 
 // Convert from time.Time
 stdTime := time.Now()
@@ -319,8 +328,8 @@ if err != nil {
 ## CI/CD Pipeline
 
 The GitHub Actions workflow enforces:
-1. **Tests pass** on Go 1.20+ with race detection
-2. **Linting passes** with golangci-lint
+1. **Tests pass** on Go 1.27+ with race detection
+2. **Linting passes** with golangci-lint (v2 config schema)
 3. **go.mod is tidy**: `go mod tidy` produces no changes
 4. **Generated code is in sync**: Timezone packages match `timezones.yaml`
 5. **Coverage tracking**: Reports uploaded to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-06-20
+
+### Added
+- `Time[TZ].To[TZ2]()` generic method for fluent, type-safe timezone
+  conversion: `eastern.To[pt.Timezone]()` is the method form of
+  `pt.FromMoment(eastern)` and chains naturally
+  (`t.To[utc.Timezone]().To[pt.Timezone]()`). This relies on generic methods,
+  a language feature introduced in Go 1.27.
+
+### Changed
+- **BREAKING**: Module path is now `github.com/matthalp/go-meridian/v3`.
+- **BREAKING**: Minimum supported Go version is now 1.27 (was 1.20), required
+  by the generic `To` method.
+- Migrated the golangci-lint configuration to the v2 schema and updated CI to
+  build and test against Go 1.27.
+
+### Notes
+- `FromMoment` is unchanged and remains the way to convert from a plain
+  `time.Time` (which has no `To` method). The `To` method is additive sugar for
+  `meridian.Time[TZ]` → `meridian.Time[TZ2]` conversions.
+
 ## [2.0.0] - 2024-10-30
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,6 @@ install-tools:
 	@echo "Installing golangci-lint..."
 	@which golangci-lint > /dev/null || \
 		(echo "Installing golangci-lint..." && \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2)
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest)
 	@echo "Tools installed successfully!"
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ Meridian solves a fundamental problem: timezone information in `time.Time` is da
 Install the package in your Go project:
 
 ```bash
-go get github.com/matthalp/go-meridian/v2
+go get github.com/matthalp/go-meridian/v3
 ```
+
+> **Requires Go 1.27 or later.** v3 uses generic methods (the `To` conversion
+> method), a language feature introduced in Go 1.27. If you are on an older Go
+> toolchain, use [v2](https://pkg.go.dev/github.com/matthalp/go-meridian/v2),
+> which offers the same conversions through package-level `FromMoment` functions.
 
 ## Quick Start
 
@@ -38,8 +43,8 @@ import (
     "fmt"
     "time"
     
-    "github.com/matthalp/go-meridian/v2/et"
-    "github.com/matthalp/go-meridian/v2/utc"
+    "github.com/matthalp/go-meridian/v3/timezones/et"
+    "github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func main() {
@@ -85,29 +90,29 @@ formatted := t.Format(time.Kitchen) // Definitely UTC! ✅
 For backwards compatibility, all existing timezones are available at both root and in the `timezones/` directory:
 
 **Root-level imports:**
-- `github.com/matthalp/go-meridian/v2/aest` - Australian Eastern Time (Australia/Sydney)
-- `github.com/matthalp/go-meridian/v2/brt` - Brasília Time (America/Sao_Paulo)
-- `github.com/matthalp/go-meridian/v2/cet` - Central European Time (Europe/Paris)
-- `github.com/matthalp/go-meridian/v2/cst` - China Standard Time (Asia/Shanghai)
-- `github.com/matthalp/go-meridian/v2/ct` - Central Time (America/Chicago)
-- `github.com/matthalp/go-meridian/v2/est` - Eastern Standard Time (America/New_York)
-- `github.com/matthalp/go-meridian/v2/et` - Eastern Time (America/New_York)
-- `github.com/matthalp/go-meridian/v2/gmt` - Greenwich Mean Time (Europe/London)
-- `github.com/matthalp/go-meridian/v2/hkt` - Hong Kong Time (Asia/Hong_Kong)
-- `github.com/matthalp/go-meridian/v2/ist` - India Standard Time (Asia/Kolkata)
-- `github.com/matthalp/go-meridian/v2/jst` - Japan Standard Time (Asia/Tokyo)
-- `github.com/matthalp/go-meridian/v2/mt` - Mountain Time (America/Denver)
-- `github.com/matthalp/go-meridian/v2/pt` - Pacific Time (America/Los_Angeles)
-- `github.com/matthalp/go-meridian/v2/pst` - Pacific Standard Time (America/Los_Angeles)
-- `github.com/matthalp/go-meridian/v2/sgt` - Singapore Time (Asia/Singapore)
-- `github.com/matthalp/go-meridian/v2/utc` - Coordinated Universal Time
+- `github.com/matthalp/go-meridian/v3/aest` - Australian Eastern Time (Australia/Sydney)
+- `github.com/matthalp/go-meridian/v3/brt` - Brasília Time (America/Sao_Paulo)
+- `github.com/matthalp/go-meridian/v3/cet` - Central European Time (Europe/Paris)
+- `github.com/matthalp/go-meridian/v3/cst` - China Standard Time (Asia/Shanghai)
+- `github.com/matthalp/go-meridian/v3/ct` - Central Time (America/Chicago)
+- `github.com/matthalp/go-meridian/v3/est` - Eastern Standard Time (America/New_York)
+- `github.com/matthalp/go-meridian/v3/et` - Eastern Time (America/New_York)
+- `github.com/matthalp/go-meridian/v3/gmt` - Greenwich Mean Time (Europe/London)
+- `github.com/matthalp/go-meridian/v3/hkt` - Hong Kong Time (Asia/Hong_Kong)
+- `github.com/matthalp/go-meridian/v3/ist` - India Standard Time (Asia/Kolkata)
+- `github.com/matthalp/go-meridian/v3/jst` - Japan Standard Time (Asia/Tokyo)
+- `github.com/matthalp/go-meridian/v3/mt` - Mountain Time (America/Denver)
+- `github.com/matthalp/go-meridian/v3/pt` - Pacific Time (America/Los_Angeles)
+- `github.com/matthalp/go-meridian/v3/pst` - Pacific Standard Time (America/Los_Angeles)
+- `github.com/matthalp/go-meridian/v3/sgt` - Singapore Time (Asia/Singapore)
+- `github.com/matthalp/go-meridian/v3/utc` - Coordinated Universal Time
 
 ### Alternative: Timezones Directory (Future)
 
 In future versions, timezone packages may be organized in a `timezones/` directory:
 
-- `github.com/matthalp/go-meridian/v2/timezones/aest`
-- `github.com/matthalp/go-meridian/v2/timezones/et`
+- `github.com/matthalp/go-meridian/v3/timezones/aest`
+- `github.com/matthalp/go-meridian/v3/timezones/et`
 - etc.
 
 Currently, all timezone packages are available at the root level as shown above.
@@ -126,15 +131,20 @@ Note: `ParseInLocation` is not needed as timezone packages already have their lo
 
 ## Converting Between Timezones
 
-Meridian provides seamless timezone conversion while preserving type safety:
+Meridian provides seamless timezone conversion while preserving type safety.
+Use the `To` method (the fluent, method form) for `Time` → `Time` conversions:
 
 ```go
-// Convert between timezone types
+// Convert between timezone types with the To method (Go 1.27 generic methods)
 etTime := et.Date(2024, time.December, 25, 10, 30, 0, 0)
-utcTime := utc.FromMoment(etTime)  // Same moment, displayed as UTC
-ptTime := pt.FromMoment(etTime)  // Same moment, displayed as PT
+utcTime := etTime.To[utc.Timezone]()  // Same moment, displayed as UTC
+ptTime := etTime.To[pt.Timezone]()    // Same moment, displayed as PT
 
-// Convert from standard time.Time
+// Conversions chain naturally
+ptTime = etTime.To[utc.Timezone]().To[pt.Timezone]()
+
+// Convert from a standard time.Time using a package's FromMoment
+// (time.Time has no To method)
 stdTime := time.Now()
 typedTime := utc.FromMoment(stdTime)  // Now type-safe!
 
@@ -142,7 +152,10 @@ typedTime := utc.FromMoment(stdTime)  // Now type-safe!
 fmt.Println(etTime.UTC().Equal(utcTime.UTC()))  // true
 ```
 
-The `Moment` interface allows both `time.Time` and `meridian.Time[TZ]` to be used interchangeably for conversions, providing flexibility while maintaining type safety where it matters.
+Both forms are equivalent for `Time` → `Time` conversion — `etTime.To[pt.Timezone]()`
+is the method form of `pt.FromMoment(etTime)`. The `Moment` interface still allows
+both `time.Time` and `meridian.Time[TZ]` to be used interchangeably with `FromMoment`,
+providing flexibility while maintaining type safety where it matters.
 
 ## Adding Custom Timezones
 
@@ -164,7 +177,7 @@ As of v2.0.0, timezone packages are automatically generated from the `timezones.
 
 3. **Import and use**:
    ```go
-   import "github.com/matthalp/go-meridian/v2/jst"
+   import "github.com/matthalp/go-meridian/v3/jst"
    
    now := jst.Now()
    ```
@@ -270,7 +283,7 @@ Coverage reports are automatically uploaded to Codecov for tracking test coverag
 
 ## API Documentation
 
-For detailed API documentation, see [pkg.go.dev](https://pkg.go.dev/github.com/matthalp/go-meridian/v2) once the package is published.
+For detailed API documentation, see [pkg.go.dev](https://pkg.go.dev/github.com/matthalp/go-meridian/v3) once the package is published.
 
 ## Publishing a New Version
 
@@ -291,8 +304,8 @@ To make your package available for others to use:
    ```
 
 3. **The package will be automatically available** via `go get`:
-   - Others can install with: `go get github.com/matthalp/go-meridian/v2@v2.0.0`
-   - Documentation will appear on [pkg.go.dev](https://pkg.go.dev/github.com/matthalp/go-meridian/v2) within minutes
+   - Others can install with: `go get github.com/matthalp/go-meridian/v3@v2.0.0`
+   - Documentation will appear on [pkg.go.dev](https://pkg.go.dev/github.com/matthalp/go-meridian/v3) within minutes
 
 4. **Update the version** in `meridian.go` when releasing new versions
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -7,8 +7,11 @@
 Install the meridian package and timezone subpackages:
 
 ```bash
-go get github.com/matthalp/go-meridian/v2
+go get github.com/matthalp/go-meridian/v3
 ```
+
+> **Requires Go 1.27 or later.** v3 uses generic methods (the `To` conversion
+> method), introduced in Go 1.27. On older toolchains, use v2.
 
 ### Basic Usage - Timezone Packages
 
@@ -21,9 +24,9 @@ import (
     "fmt"
     "time"
     
-    "github.com/matthalp/go-meridian/v2/est"
-    "github.com/matthalp/go-meridian/v2/pst"
-    "github.com/matthalp/go-meridian/utc"
+    "github.com/matthalp/go-meridian/v3/timezones/est"
+    "github.com/matthalp/go-meridian/v3/timezones/pst"
+    "github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func main() {
@@ -51,8 +54,8 @@ package main
 
 import (
     "database/sql"
-    "github.com/matthalp/go-meridian/v2/timezones/utc"
-    "github.com/matthalp/go-meridian/v2/timezones/est"
+    "github.com/matthalp/go-meridian/v3/timezones/utc"
+    "github.com/matthalp/go-meridian/v3/timezones/est"
 )
 
 // Function only accepts UTC times
@@ -84,7 +87,8 @@ func main() {
 
 ### Converting Between Timezones
 
-Meridian provides `Convert()` functions in each timezone package to convert between timezones:
+For `Time` → `Time` conversions, use the `To` method (a Go 1.27 generic method).
+It is the fluent equivalent of a package's `FromMoment` function and chains:
 
 ```go
 package main
@@ -93,18 +97,22 @@ import (
     "fmt"
     "time"
     
-    "github.com/matthalp/go-meridian/v2/est"
-    "github.com/matthalp/go-meridian/v2/pst"
-    "github.com/matthalp/go-meridian/utc"
+    "github.com/matthalp/go-meridian/v3/timezones/est"
+    "github.com/matthalp/go-meridian/v3/timezones/pst"
+    "github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func main() {
     // Create a time in EST
     meeting := est.Date(2024, time.December, 25, 10, 30, 0, 0)
     
-    // Convert to other timezones
-    utcMeeting := utc.Convert(meeting)
-    pstMeeting := pst.Convert(meeting)
+    // Convert to other timezones with the To method
+    utcMeeting := meeting.To[utc.Timezone]()
+    pstMeeting := meeting.To[pst.Timezone]()
+    
+    // Equivalent package-function form:
+    //   utcMeeting := utc.FromMoment(meeting)
+    //   pstMeeting := pst.FromMoment(meeting)
     
     fmt.Printf("EST: %s\n", meeting.Format(time.Kitchen))    // 10:30AM
     fmt.Printf("UTC: %s\n", utcMeeting.Format(time.Kitchen)) // 3:30PM
@@ -118,21 +126,22 @@ func main() {
 
 ### Converting from time.Time
 
-The `Moment` interface allows seamless conversion from standard `time.Time`:
+The `Moment` interface allows seamless conversion from standard `time.Time`.
+Use `FromMoment` for this — a plain `time.Time` has no `To` method:
 
 ```go
 package main
 
 import (
     "time"
-    "github.com/matthalp/go-meridian/v2/timezones/utc"
-    "github.com/matthalp/go-meridian/v2/timezones/est"
+    "github.com/matthalp/go-meridian/v3/timezones/utc"
+    "github.com/matthalp/go-meridian/v3/timezones/est"
 )
 
 func processStandardTime(stdTime time.Time) {
     // Convert to type-safe timezone types
-    utcTime := utc.Convert(stdTime)
-    estTime := est.Convert(stdTime)
+    utcTime := utc.FromMoment(stdTime)
+    estTime := est.FromMoment(stdTime)
     
     // Now you have type-safe times for your functions
     storeInDatabase(utcTime)     // Function requires utc.Time
@@ -154,9 +163,9 @@ import (
     "fmt"
     "time"
     
-    "github.com/matthalp/go-meridian/v2/est"
-    "github.com/matthalp/go-meridian/v2/pst"
-    "github.com/matthalp/go-meridian/utc"
+    "github.com/matthalp/go-meridian/v3/timezones/est"
+    "github.com/matthalp/go-meridian/v3/timezones/pst"
+    "github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func main() {
@@ -242,7 +251,7 @@ package main
 
 import (
     "time"
-    "github.com/matthalp/go-meridian/v2"
+    "github.com/matthalp/go-meridian/v3"
 )
 
 // Define a custom timezone
@@ -266,21 +275,19 @@ func main() {
 
 ```
 go-meridian/
-├── meridian.go          # Core generic types and functions
-├── meridian_test.go     # Core package tests
-├── example_test.go      # Testable examples (appear in docs)
-├── doc.go               # Package-level documentation
-├── cmd/example/         # Example program using the package
-├── utc/                 # UTC timezone package
-│   ├── utc.go
-│   └── utc_test.go
-├── est/                 # EST timezone package
-│   ├── est.go
-│   └── est_test.go
-├── pst/                 # PST timezone package
-│   ├── pst.go
-│   └── pst_test.go
-└── ...                  # CI/CD and config files
+├── meridian.go              # Core generic types and functions
+├── meridian_test.go         # Core package tests
+├── example_test.go          # Testable examples (appear in docs)
+├── doc.go                   # Package-level documentation
+├── timezones.yaml           # Timezone definitions (source of generated packages)
+├── cmd/example/             # Example program using the package
+├── cmd/generate-timezones/  # Code generator for timezone packages
+├── timezones/               # Generated timezone packages
+│   ├── utc/                 # UTC timezone package (utc.go, utc_test.go)
+│   ├── est/                 # EST timezone package
+│   ├── pst/                 # PST timezone package
+│   └── ...                  # et, pt, ct, mt, jst, ist, and more
+└── ...                      # CI/CD and config files
 ```
 
 ### Key Concepts
@@ -322,72 +329,34 @@ go-meridian/
 
 ### Adding New Timezone Packages
 
-To add a new timezone package (e.g., `jst` for Japan Standard Time):
+Timezone packages are **generated** from `timezones.yaml` — you do not write them
+by hand. To add a new timezone (e.g., `jst` for Japan Standard Time):
 
-1. Create a new directory `jst/` with `jst.go`:
-   ```go
-   package jst
-   
-   import (
-       "fmt"
-       "time"
-       "github.com/matthalp/go-meridian/v2"
-   )
-   
-   var location = mustLoadLocation("Asia/Tokyo")
-   
-   func mustLoadLocation(name string) *time.Location {
-       loc, err := time.LoadLocation(name)
-       if err != nil {
-           panic(fmt.Sprintf("failed to load timezone %s: %v", name, err))
-       }
-       return loc
-   }
-   
-   type Timezone struct{}
-   
-   func (Timezone) Location() *time.Location {
-       return location
-   }
-   
-   type Time = meridian.Time[Timezone]
-   
-   func Now() Time {
-       return meridian.Now[Timezone]()
-   }
-   
-   func Date(year int, month time.Month, day, hour, minute, sec, nsec int) Time {
-       return meridian.Date[Timezone](year, month, day, hour, minute, sec, nsec)
-   }
-   
-   func Convert(m meridian.Moment) Time {
-       return meridian.FromMoment[Timezone](m)
-   }
-   
-   func Parse(layout, value string) (Time, error) {
-       t, err := time.ParseInLocation(layout, value, location)
-       if err != nil {
-           return Time{}, err
-       }
-       return meridian.FromMoment[Timezone](t), nil
-   }
-   
-   func Unix(sec, nsec int64) Time {
-       return meridian.FromMoment[Timezone](time.Unix(sec, nsec))
-   }
-   
-   func UnixMilli(msec int64) Time {
-       return meridian.FromMoment[Timezone](time.UnixMilli(msec))
-   }
-   
-   func UnixMicro(usec int64) Time {
-       return meridian.FromMoment[Timezone](time.UnixMicro(usec))
-   }
+1. Add an entry to `timezones.yaml`:
+   ```yaml
+   timezones:
+     - name: jst
+       location: Asia/Tokyo
+       description: Japan Standard Time
    ```
 
-2. Add tests in `jst/jst_test.go` following the pattern in `utc/utc_test.go`
+2. Regenerate the packages:
+   ```bash
+   make generate
+   ```
+   This creates `timezones/jst/jst.go` and `timezones/jst/jst_test.go`, each
+   wired to the core `meridian` API (`Now`, `Date`, `FromMoment`, `Parse`,
+   `Unix`, `UnixMilli`, `UnixMicro`).
 
-3. Update documentation to include the new timezone package
+3. Verify:
+   ```bash
+   make test   # generated tests pass
+   make lint   # code quality
+   ```
+
+CI fails if the generated packages are out of sync with `timezones.yaml`, so
+always commit the regenerated files. To convert between any two generated
+timezones, use the `To` method (e.g. `jst.Now().To[utc.Timezone]()`).
 
 ### Publishing Updates
 

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
-	"github.com/matthalp/go-meridian/v2/timezones/et"
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3"
+	"github.com/matthalp/go-meridian/v3/timezones/et"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func main() {
@@ -47,11 +47,11 @@ func main() {
 	// Note: printUTCTime(et.Now()) would not compile due to type safety
 	fmt.Println()
 
-	// Example 5: Converting between timezones
+	// Example 5: Converting between timezones with the To method (Go 1.27)
 	fmt.Println("5. Timezone Conversion:")
 	etMeeting := et.Date(2024, time.December, 25, 10, 30, 0, 0)
-	utcMeeting := utc.FromMoment(etMeeting)
-	ptMeeting := pt.FromMoment(etMeeting)
+	utcMeeting := etMeeting.To[utc.Timezone]()
+	ptMeeting := etMeeting.To[pt.Timezone]()
 
 	fmt.Printf("   Meeting ET: %s\n", etMeeting.Format(time.Kitchen))
 	fmt.Printf("   Meeting UTC: %s\n", utcMeeting.Format(time.Kitchen))

--- a/cmd/generate-timezones/main.go
+++ b/cmd/generate-timezones/main.go
@@ -176,7 +176,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.
@@ -252,10 +252,10 @@ import (
 {{- if or (ne .PackageName "pt") (ne .PackageName "utc")}}
 
 {{- if ne .PackageName "pt"}}
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
 {{- end}}
 {{- if ne .PackageName "utc"}}
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 {{- end}}
 {{- end}}
 )

--- a/doc.go
+++ b/doc.go
@@ -18,9 +18,9 @@ Meridian makes timezone information immutable by encoding it directly into the t
 Meridian's Time[TZ] type carries timezone information as a type parameter:
 
 	import (
-		"github.com/matthalp/go-meridian/v2/timezones/et"
-		"github.com/matthalp/go-meridian/v2/timezones/pt"
-		"github.com/matthalp/go-meridian/v2/timezones/utc"
+		"github.com/matthalp/go-meridian/v3/timezones/et"
+		"github.com/matthalp/go-meridian/v3/timezones/pt"
+		"github.com/matthalp/go-meridian/v3/timezones/utc"
 	)
 
 	func SaveDeadline(t utc.Time) {
@@ -45,11 +45,14 @@ and meridian.Time[pt.PT] are as different as string and int.
 Per-Timezone Packages: Each timezone has its own package (et, pt, utc, etc.)
 with convenience functions like et.Now() and pt.Date(...).
 
-Explicit Conversions: Converting between timezones requires explicit function calls:
+Explicit Conversions: Converting between timezones requires explicit, visible
+calls. Use the To method (a generic method, available in Go 1.27+) for the
+fluent form, or a package's FromMoment when starting from a plain time.Time:
 
 	eastern := et.Now()
-	pacific := pt.FromMoment(eastern)  // Explicit conversion
-	utcTime := utc.FromMoment(eastern)  // Convert to UTC for storage
+	pacific := eastern.To[pt.Timezone]()   // fluent method form
+	utcTime := eastern.To[utc.Timezone]()  // convert to UTC for storage
+	pacific = pt.FromMoment(eastern)       // equivalent package-function form
 
 The Moment Interface: Both time.Time and meridian.Time[TZ] implement Moment,
 enabling seamless interoperability:
@@ -81,8 +84,9 @@ Create times in specific timezones:
 Convert between timezones explicitly:
 
 	eastern := et.Date(2024, time.December, 25, 9, 0, 0, 0)
-	pacific := pt.FromMoment(eastern)  // Same moment, different timezone
-	utcTime := utc.FromMoment(eastern)  // Convert to UTC
+	pacific := eastern.To[pt.Timezone]()   // Same moment, different timezone
+	utcTime := eastern.To[utc.Timezone]()  // Convert to UTC
+	pacific = pt.FromMoment(eastern)       // Or the package-function form
 
 Work with time.Time seamlessly:
 
@@ -127,9 +131,16 @@ The package includes these timezone packages:
 
 Additional timezones can be generated using the timezones.yaml configuration.
 
+# Requirements
+
+Meridian v3 requires Go 1.27 or later. The To method is a generic method, a
+language feature introduced in Go 1.27. Projects on older Go toolchains should
+use v2, which provides the same conversions through package-level FromMoment
+functions.
+
 # Installation
 
-	go get github.com/matthalp/go-meridian/v2
+	go get github.com/matthalp/go-meridian/v3
 
 # Design Philosophy
 

--- a/example_test.go
+++ b/example_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
-	"github.com/matthalp/go-meridian/v2/timezones/et"
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3"
+	"github.com/matthalp/go-meridian/v3/timezones/et"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func ExampleNow() {
@@ -56,6 +56,30 @@ func ExampleFromMoment() {
 	fmt.Println("PT:", pacific.Format("15:04 MST"))
 	fmt.Println("UTC:", universal.Format("15:04 MST"))
 	fmt.Println("Same moment:", eastern.Equal(pacific) && eastern.Equal(universal))
+	// Output:
+	// ET: 09:00 EST
+	// PT: 06:00 PST
+	// UTC: 14:00 UTC
+	// Same moment: true
+}
+
+// ExampleTime_To demonstrates the fluent method form of timezone conversion,
+// enabled by Go 1.27 generic methods.
+func ExampleTime_To() {
+	// Create a time in Eastern timezone
+	eastern := et.Date(2024, time.December, 25, 9, 0, 0, 0)
+
+	// Convert with the To method instead of pt.FromMoment(eastern)
+	pacific := eastern.To[pt.Timezone]()
+	universal := eastern.To[utc.Timezone]()
+
+	// Conversions chain naturally
+	roundTrip := eastern.To[utc.Timezone]().To[pt.Timezone]()
+
+	fmt.Println("ET:", eastern.Format("15:04 MST"))
+	fmt.Println("PT:", pacific.Format("15:04 MST"))
+	fmt.Println("UTC:", universal.Format("15:04 MST"))
+	fmt.Println("Same moment:", eastern.Equal(pacific) && eastern.Equal(roundTrip))
 	// Output:
 	// ET: 09:00 EST
 	// PT: 06:00 PST

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/matthalp/go-meridian/v2
+module github.com/matthalp/go-meridian/v3
 
-go 1.20
+go 1.27rc1
 
 require gopkg.in/yaml.v3 v3.0.1

--- a/meridian.go
+++ b/meridian.go
@@ -19,7 +19,7 @@ timezone, causing incorrect behavior.
 Meridian encodes timezone information directly in the type system using Go generics.
 Time[TZ] is a time.Time wrapper where TZ is a timezone type parameter:
 
-	import "github.com/matthalp/go-meridian/utc"
+	import "github.com/matthalp/go-meridian/v3/timezones/utc"
 
 	func ProcessDeadline(deadline utc.Time) {
 		// Now the timezone is guaranteed by the compiler!
@@ -40,11 +40,14 @@ meridian.Time[pt.PT] cannot be mixed without explicit conversion:
 Type-Safe Times: Time[TZ] carries timezone information as a type parameter,
 making timezone part of the type system rather than runtime data.
 
-Explicit Conversions: Converting between timezones requires explicit function calls
-using the FromMoment function, making timezone handling visible in code review:
+Explicit Conversions: Converting between timezones requires explicit, visible
+calls so timezone handling shows up in code review. Use the To method for the
+fluent method form, or a timezone package's FromMoment when starting from a
+plain time.Time:
 
 	eastern := et.Now()
-	pacific := pt.FromMoment(eastern)  // Explicit and reviewable
+	pacific := eastern.To[pt.PT]()     // method form (Go 1.27 generic methods)
+	pacific = pt.FromMoment(eastern)   // package-function form; also for time.Time
 
 Moment Interface: Both time.Time and Time[TZ] implement the Moment interface,
 enabling seamless interoperability with existing code:
@@ -81,7 +84,7 @@ import (
 )
 
 // Version is the current version of the meridian package.
-const Version = "2.0.1"
+const Version = "3.0.0"
 
 // Timezone interface that all timezone types must implement.
 // Each timezone package defines its own Timezone type that satisfies this interface,
@@ -217,6 +220,22 @@ func (t Time[TZ]) GoString() string {
 // both time.Time and other Time[TZ] types. The returned time.Time is always in UTC.
 func (t Time[TZ]) UTC() time.Time {
 	return t.utcTime
+}
+
+// To converts t to the same instant expressed in the timezone TZ2, preserving
+// the moment in time (UTC equality) while changing the timezone type.
+//
+// To is the method form of the package-level FromMoment function and reads
+// fluently at the call site:
+//
+//	eastern := et.Now()
+//	pacific := eastern.To[pt.PT]()  // same instant, Pacific type
+//
+// It relies on generic methods, a language feature added in Go 1.27. Because
+// To operates on an existing Time[TZ], it cannot start from a plain time.Time;
+// use a timezone package's FromMoment (e.g. utc.FromMoment(stdTime)) for that.
+func (t Time[TZ]) To[TZ2 Timezone]() Time[TZ2] {
+	return Time[TZ2]{utcTime: t.utcTime}
 }
 
 // Time Arithmetic & Manipulation

--- a/meridian_test.go
+++ b/meridian_test.go
@@ -551,6 +551,44 @@ func TestAddDateAcrossDST(t *testing.T) {
 	}
 }
 
+// TestTo verifies the generic To method preserves the instant while changing
+// the timezone type, matching FromMoment and supporting chained conversions.
+func TestTo(t *testing.T) {
+	// 2024-01-15 17:00:00 UTC.
+	original := Date[UTC](2024, time.January, 15, 17, 0, 0, 0)
+
+	t.Run("preserves instant across type change", func(t *testing.T) {
+		eastern := original.To[EST]()
+		pacific := original.To[PST]()
+
+		if !eastern.UTC().Equal(original.UTC()) {
+			t.Errorf("To[EST]() UTC = %v, want %v", eastern.UTC(), original.UTC())
+		}
+		if !pacific.UTC().Equal(original.UTC()) {
+			t.Errorf("To[PST]() UTC = %v, want %v", pacific.UTC(), original.UTC())
+		}
+	})
+
+	t.Run("matches FromMoment", func(t *testing.T) {
+		if got, want := original.To[PST]().UTC(), FromMoment[PST](original).UTC(); !got.Equal(want) {
+			t.Errorf("To[PST]() = %v, FromMoment[PST]() = %v; want equal", got, want)
+		}
+	})
+
+	t.Run("chains and round-trips", func(t *testing.T) {
+		roundTrip := original.To[EST]().To[PST]().To[UTC]()
+		if !roundTrip.UTC().Equal(original.UTC()) {
+			t.Errorf("round-trip To chain UTC = %v, want %v", roundTrip.UTC(), original.UTC())
+		}
+	})
+
+	t.Run("converting to same type is identity", func(t *testing.T) {
+		if got := original.To[UTC](); !got.UTC().Equal(original.UTC()) {
+			t.Errorf("To[UTC]() UTC = %v, want %v", got.UTC(), original.UTC())
+		}
+	})
+}
+
 func TestSub(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/timezones/aest/aest.go
+++ b/timezones/aest/aest.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/aest/aest_test.go
+++ b/timezones/aest/aest_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestAESTLocation(t *testing.T) {

--- a/timezones/brt/brt.go
+++ b/timezones/brt/brt.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/brt/brt_test.go
+++ b/timezones/brt/brt_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestBRTLocation(t *testing.T) {

--- a/timezones/cet/cet.go
+++ b/timezones/cet/cet.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/cet/cet_test.go
+++ b/timezones/cet/cet_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestCETLocation(t *testing.T) {

--- a/timezones/cst/cst.go
+++ b/timezones/cst/cst.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/cst/cst_test.go
+++ b/timezones/cst/cst_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestCSTLocation(t *testing.T) {

--- a/timezones/ct/ct.go
+++ b/timezones/ct/ct.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/ct/ct_test.go
+++ b/timezones/ct/ct_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestCTLocation(t *testing.T) {

--- a/timezones/est/est.go
+++ b/timezones/est/est.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/est/est_test.go
+++ b/timezones/est/est_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestESTLocation(t *testing.T) {

--- a/timezones/et/et.go
+++ b/timezones/et/et.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/et/et_test.go
+++ b/timezones/et/et_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestETLocation(t *testing.T) {

--- a/timezones/gmt/gmt.go
+++ b/timezones/gmt/gmt.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/gmt/gmt_test.go
+++ b/timezones/gmt/gmt_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestGMTLocation(t *testing.T) {

--- a/timezones/hkt/hkt.go
+++ b/timezones/hkt/hkt.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/hkt/hkt_test.go
+++ b/timezones/hkt/hkt_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestHKTLocation(t *testing.T) {

--- a/timezones/ist/ist.go
+++ b/timezones/ist/ist.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/ist/ist_test.go
+++ b/timezones/ist/ist_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestISTLocation(t *testing.T) {

--- a/timezones/jst/jst.go
+++ b/timezones/jst/jst.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/jst/jst_test.go
+++ b/timezones/jst/jst_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestJSTLocation(t *testing.T) {

--- a/timezones/mt/mt.go
+++ b/timezones/mt/mt.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/mt/mt_test.go
+++ b/timezones/mt/mt_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestMTLocation(t *testing.T) {

--- a/timezones/pst/pst.go
+++ b/timezones/pst/pst.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/pst/pst_test.go
+++ b/timezones/pst/pst_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestPSTLocation(t *testing.T) {

--- a/timezones/pt/pt.go
+++ b/timezones/pt/pt.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/pt/pt_test.go
+++ b/timezones/pt/pt_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestPTLocation(t *testing.T) {

--- a/timezones/sgt/sgt.go
+++ b/timezones/sgt/sgt.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/sgt/sgt_test.go
+++ b/timezones/sgt/sgt_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
-	"github.com/matthalp/go-meridian/v2/timezones/utc"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/utc"
 )
 
 func TestSGTLocation(t *testing.T) {

--- a/timezones/utc/utc.go
+++ b/timezones/utc/utc.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2"
+	"github.com/matthalp/go-meridian/v3"
 )
 
 // location is the IANA timezone location, loaded once at package initialization.

--- a/timezones/utc/utc_test.go
+++ b/timezones/utc/utc_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matthalp/go-meridian/v2/timezones/pt"
+	"github.com/matthalp/go-meridian/v3/timezones/pt"
 )
 
 func TestUTCLocation(t *testing.T) {


### PR DESCRIPTION
## Summary

Introduces **v3**, targeting **Go 1.27**, which adds a long-requested member-function form of timezone conversion. Go 1.27's headline language feature — [generic methods](https://tip.golang.org/doc/go1.27) (a method may declare its own type parameters) — is exactly what was missing: it's why conversions previously had to go through the package-level `FromMoment` function.

### New API

```go
eastern := et.Now()
pacific  := eastern.To[pt.Timezone]()                     // fluent method form
utcNow   := eastern.To[utc.Timezone]().To[pt.Timezone]()  // chains naturally
```

`eastern.To[pt.Timezone]()` is the method-form equivalent of `pt.FromMoment(eastern)`. `FromMoment` is **kept** — it's still required to convert from a plain `time.Time` (which has no method), so `To` is purely additive sugar for `Time → Time`.

## Changes

**Core**
- Add `func (t Time[TZ]) To[TZ2 Timezone]() Time[TZ2]` (`meridian.go`).
- Bump `Version` to `3.0.0`.

**Module / toolchain** (breaking)
- Module path `…/go-meridian/v2` → `…/v3`.
- `go` directive `1.20` → `1.27rc1` (bump to `1.27` once it GAs — a `go 1.27` directive would reject the rc1 toolchain as too old).
- Regenerated all 16 timezone packages + generator template for the new import path (import-line change only).

**Tooling / CI**
- Migrated `.golangci.yml` to the golangci-lint **v2** schema (verified it loads/runs locally); Makefile installer → golangci-lint v2.
- CI: Go `1.27.0-rc.1`, `actions/setup-go@v5`, `golangci-lint-action@v8`.

**Docs / tests**
- New `TestTo` + `ExampleTime_To`; `cmd/example` demos `To`.
- Updated `doc.go`, `README`, `AGENTS.md`, `CHANGELOG`.
- Overhauled `USAGE.md`: fixed broken/unversioned import paths, replaced the nonexistent `Convert()` API with `FromMoment`/`To`, and rewrote the "add a timezone" flow to use the generator.

## Verification

Locally on `go1.27rc1` (auto-downloaded via `GOTOOLCHAIN`):
- ✅ `go build ./...`, `go vet ./...`, `go test -race ./...` (incl. new test/example)
- ✅ `go mod tidy` — no diff
- ✅ generator regen — in sync, no untracked files

## ⚠️ Known CI caveat

The **lint job will not pass until a golangci-lint release built against Go ≥ 1.27 is published.** golangci-lint refuses to lint code targeting a newer Go than it was built with, and none exists while 1.27 is rc-only. The v2 config itself is correct; `version: latest` will pick up a compatible build automatically once available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)